### PR TITLE
Add enter_exit_callback.

### DIFF
--- a/binary/custom-encoding/cs_decode/Makefile
+++ b/binary/custom-encoding/cs_decode/Makefile
@@ -36,4 +36,4 @@ schema.c:
 	../tool.py --schema ../schema.json5 source
 
 clean:
-	rm -f *.o schema.c
+	rm -f *.o schema.c $(TARGET)

--- a/binary/custom-encoding/cs_decode/cs_decode.h
+++ b/binary/custom-encoding/cs_decode/cs_decode.h
@@ -39,7 +39,15 @@ typedef struct {
 
 int cs_decode(
     const cs_schema_t *schema,
-    int (*callback)(const cs_path_t *path, int value),
+    /* Gets called for every simple value (integer, bool), with the path and
+     * value. */
+    int (*value_callback)(const cs_path_t *path, int value),
+    /* Gets called every time we begin/complete decoding an entry with a custom
+     * type. Path contains the complete path to the entry.
+     * A decoder can use this to tell what data it's about to receive, and also
+     * to differentiate which index in an array the current data belongs to.
+     */
+    int (*enter_exit_callback)(const cs_path_t *path, bool enter),
     uint8_t *encoded,
     unsigned type);
 

--- a/binary/custom-encoding/cs_decode/test.c
+++ b/binary/custom-encoding/cs_decode/test.c
@@ -4,12 +4,24 @@
 #include "cs_decode.h"
 #include "schema.h"
 
-int callback(const cs_path_t *path, int value)
+static int value_callback(const cs_path_t *path, int value)
 {
     for (unsigned i = 0; i < path->depth; i++) {
-        printf(".%d", path->values[i]);
+        printf("  ");
     }
-    printf(" = %d\n", value);
+    printf("%d: %d\n", path->values[path->depth - 1], value);
+    return 0;
+}
+
+static int enter_exit_callback(const cs_path_t *path, bool enter)
+{
+    for (unsigned i = 0; i < path->depth; i++) {
+        printf("  ");
+    }
+    if (enter && path->depth) {
+        printf("%d: ", path->values[path->depth - 1]);
+    }
+    printf("%s\n", enter ? "{" : "}");
     return 0;
 }
 
@@ -34,6 +46,9 @@ int main(int argc, char *argv[])
     }
     fclose(fp);
 
-    cs_decode(&schema_schema, callback, encoded, TYPE_CONFIGURATION);
+    cs_decode(&schema_schema,
+              value_callback,
+              enter_exit_callback,
+              encoded, TYPE_CONFIGURATION);
     free(encoded);
 }


### PR DESCRIPTION
Now the decoder can (and the test one does) spit out the full tree that
almost exactly matches the input JSON file. It doesn't put in array
brackets because that seems unnecessary and is extra work, but it could.

.o size before: 2354, 2450
.o size after: 2540, 2638