### PR TITLE
Add custom support for fixed-width numbers.

### DIFF
--- a/binary/custom-encoding/c_header.h
+++ b/binary/custom-encoding/c_header.h
@@ -4,13 +4,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-/* Built-in type. */
-enum {
-    BUILTIN_NUMBER,
-    BUILTIN_BOOLEAN,
-    BUILTIN_END
-};
-
 /*
  * There are a bunch of uint8_t below, to save space in the binary. With larger
  * schemas that will have to be uint16_t. (Maybe even uint32_t for some huge

--- a/binary/custom-encoding/cs_decode/Makefile
+++ b/binary/custom-encoding/cs_decode/Makefile
@@ -2,7 +2,7 @@ CFLAGS=-Os -Wall -Werror -g
 RV32_CC=riscv32-unknown-elf-gcc
 RV64_CC=riscv64-unknown-elf-gcc
 
-OBJECTS=cs_decode.o test.o schema.o
+OBJECTS=test.o schema.o
 TARGET=test
 RV32_OBJECTS=$(patsubst %.o,%-rv32.o,$(OBJECTS))
 RV64_OBJECTS=$(patsubst %.o,%-rv64.o,$(OBJECTS))
@@ -35,5 +35,10 @@ $(TARGET)-rv64:	$(RV64_OBJECTS)
 schema.c:
 	../tool.py --schema ../schema.json5 source
 
+schema.h:
+	../tool.py --schema ../schema.json5 source
+
+test.c:	schema.h
+
 clean:
-	rm -f *.o schema.c $(TARGET)
+	rm -f *.o schema.c schema.h $(TARGET)

--- a/binary/custom-encoding/cs_decode/test.c
+++ b/binary/custom-encoding/cs_decode/test.c
@@ -4,20 +4,23 @@
 #include "cs_decode.h"
 #include "schema.h"
 
-static int value_callback(const cs_path_t *path, int value)
+static void print_path_prefix(const cs_path_t *path)
 {
     for (unsigned i = 0; i < path->depth; i++) {
         printf("  ");
     }
+}
+
+static int value_callback(const cs_path_t *path, int value)
+{
+    print_path_prefix(path);
     printf("%d: %d\n", path->values[path->depth - 1], value);
     return 0;
 }
 
 static int enter_exit_callback(const cs_path_t *path, bool enter)
 {
-    for (unsigned i = 0; i < path->depth; i++) {
-        printf("  ");
-    }
+    print_path_prefix(path);
     if (enter && path->depth) {
         printf("%d: ", path->values[path->depth - 1]);
     }

--- a/binary/custom-encoding/cs_decode/test.c
+++ b/binary/custom-encoding/cs_decode/test.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "cs_decode.h"
 #include "schema.h"
 
 static void print_path_prefix(const cs_path_t *path)

--- a/binary/custom-encoding/schema.json5
+++ b/binary/custom-encoding/schema.json5
@@ -40,7 +40,7 @@
 
     // Debug Group owns this part
     debug_trigger_mcontrol: {
-        maskmax: {required: true, type: "Number", code: 1},
+        maskmax: {required: true, type: "Int6", code: 1},
         hit: {required: true, type: "Boolean", code: 2},
         address_match: {required: true, type: "Boolean", code: 3},
         data_match: {required: true, type: "Boolean", code: 4},


### PR DESCRIPTION
Supports any number of bits from 1 to 128. The user can use types by specifying Int1, Int2, Int3, all the way up to Int128.

To keep this efficient, I pulled the separate cs_decode.[ch] into the python tool, which now reads c_code.c and c_header.h and puts the contents into the files it generates.

Code size did go up a bit, from 1774/1856 to 1819/1873.