### PR TITLE
Optimize schema.asn

### DIFF
--- a/examples/example.jer
+++ b/examples/example.jer
@@ -2,21 +2,23 @@
     "harts": [
         {
             "hartid": {
-                "single": [
-                    0
-                ]
+                "hartId4": {
+                    "single": [
+                        0
+                    ]
+                }
             },
             "extension": [
                 {
                     "debug": {
                         "trigger": [
                             {
-                                "index": {
-                                    "start": [
-                                        0
-                                    ],
-                                    "end": [
-                                        3
+                                "index" : {
+                                    "range": [
+                                        {
+                                            "start": 0,
+                                            "length": 3
+                                         }
                                     ]
                                 },
                                 "mcontrol": [
@@ -110,12 +112,14 @@
         },
         {
             "hartid": {
-                "start": [
-                    1
-                ],
-                "end": [
-                    4
-                ]
+                "hartId8": {
+                    "range": [
+                        {
+                            "start": 1,
+                            "length": 4
+                        }
+                    ]
+                }
             },
             "extension": [
                 {
@@ -173,11 +177,13 @@
         },
         {
             "hartid": {
-                "single": [
-                    0,
-                    2,
-                    4
-                ]
+                "hartId8": {
+                    "single": [
+                        0,
+                        2,
+                        4
+                    ]
+                }
             },
             "extension": [
                 {
@@ -207,10 +213,12 @@
         },
         {
             "hartid": {
-                "single": [
-                    1,
-                    3
-                ]
+                "hartId4": {
+                    "single": [
+                        1,
+                        3
+                    ]
+                }
             },
             "extension": [
                 {
@@ -239,12 +247,14 @@
         },
         {
             "hartid": {
-                "start": [
-                    1
-                ],
-                "end": [
-                    4
-                ]
+                "hartId4": {
+                    "range": [
+                        {
+                            "start": 1,
+                            "length": 4
+                        }
+                    ]
+                }
             },
             "extension": [
                 {
@@ -267,22 +277,22 @@
                         "aarpostincrementSupported": false,
                         "postexecSupported": true,
                         "regno": {
-                            "start": [
-                                4096
-                            ],
-                            "end": [
-                                4127
+                            "range" : [
+                                {
+                                    "start": 4096,
+                                    "length": 31
+                                }
                             ]
                         }
                     }
                 ]
             },
             "connectedHarts": {
-                "start": [
-                    0
-                ],
-                "end": [
-                    4
+                "range" : [
+                    {
+                            "start": 0,
+                            "length": 4
+                    }
                 ]
             }
         }

--- a/schema.asn
+++ b/schema.asn
@@ -1,12 +1,68 @@
 Configuration-Structure-Schema DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+
+   -- 2-bit integer
+   Integer4 ::= INTEGER (0..3)
+
+   -- 3-bit integer
+   Integer8 ::= INTEGER (0..7)
+
+   -- 4-bit integer
+   Integer16 ::= INTEGER (0..15)
+
+   -- 2-bit integer of range [0..3]
+   Range4 ::= SEQUENCE {
+      start Integer4,
+      length Integer4
+   }
+   -- 3-bit integer of range [0..7]
+   Range8 ::= SEQUENCE {
+      start Integer8,
+      length Integer8
+   }
+   -- 4-bit integer of range [0..15]
+   Range16 ::= SEQUENCE {
+      start Integer16,
+      length Integer16
+   }
+   -- Any size of interger
    Range ::= SEQUENCE {
       start INTEGER,
       length INTEGER
    }
+
+   -- 2-bit flexible range [0..3]
+   FlexibleRange4 ::= SEQUENCE {
+      -- The count of single sequence [1..4] which is
+      -- a 2-bit count
+      single SEQUENCE SIZE(1..4) OF Integer4 OPTIONAL,
+      -- The intenger range is [0..3]
+      range SEQUENCE OF Range4 OPTIONAL,
+      ...
+   }
+
+   -- 3-bit flexible range [0..7]
+   FlexibleRange8 ::= SEQUENCE {
+      -- The count of single sequence [1..8] which is 
+      -- a 3-bit count
+      single SEQUENCE SIZE(1..8) OF Integer8 OPTIONAL,
+      -- The intenger range is [0..7]
+      range SEQUENCE OF Range8 OPTIONAL,
+      ...
+   }
+
+   -- 4-bit flexible range [0..15]
+   FlexibleRange16 ::= SEQUENCE {
+      -- The count of single sequence [1..16] which is
+      -- a 4-bit count
+      single SEQUENCE SIZE(1..16) OF Integer8 OPTIONAL,
+      -- The intenger range is [0..15]
+      range SEQUENCE OF Range16 OPTIONAL,
+      ...
+   }
+   -- Any size of flexible range
    FlexibleRange ::= SEQUENCE {
       single SEQUENCE OF INTEGER OPTIONAL,
-      start SEQUENCE OF INTEGER OPTIONAL,
-      end SEQUENCE OF INTEGER OPTIONAL,
+      range SEQUENCE OF Range OPTIONAL,
       ...
    }
    HartExtension ::= CHOICE {
@@ -18,7 +74,12 @@ Configuration-Structure-Schema DEFINITIONS AUTOMATIC TAGS ::= BEGIN
          ...
    }
    Hart ::= SEQUENCE {
-      hartid FlexibleRange,
+      hartid CHOICE { /* 4 choices use 2-bit as the index*/
+        hartId4  FlexibleRange4, /* For hart number [1..4] */
+        hartId8  FlexibleRange8, /* For hart number [1..8] */
+        hartId16 FlexibleRange8, /* For hart number [1..16] */
+        hartId   FlexibleRange   /* For hart number > 16 */
+      },
       extension SEQUENCE OF HartExtension OPTIONAL,
       ...
    }


### PR DESCRIPTION
Optimize schema.asn in below manners,
- Define different sizes of integer
- Define different sizes of Range
- Define different sizes of FlexibleRange
- Limit the number of bits used for the count of "SEQUENCE OF single"
- Define variant of hartid based on different sizes of integer.

examples/example.asn is 91B in UPER

Total encoded length = 90.6
Encoded successfully in 91 bytes:
702A2001 04091010 10001030 10104FFF FFFFFA40 20208020 20800000 00052026
00820290 08082008 08200000 0001520A 010B64FD F44B8109 49D02A40 4C014604
24680424 68026802 92020420 00023E40 40400041 1C040004 000480