### PR TITLE
Fix rvcs test on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RISC-V Configuration structure
 
-Layout of files here:
+## Layout of files here
 - asn1c/ contains files related to the C asn1c tool. This is where you want to
   start if you're interested in what a C decoder would look like.
 - asn1tools/ contains files related to the python asn1tools library. This is
@@ -8,3 +8,7 @@ Layout of files here:
 - examples/ contains human-readable examples.
 - schema.asn is the ASN.1 schema used that contains the configuration structure
   format.
+
+## Test changes
+
+`make test` or `./asn1tools/rvcs.py test examples/*.jer`


### PR DESCRIPTION
Don't use tempfile and then open that same file again. In fact, there's
no need for a temporary file at all.

Also mention how to run the test in README.md.