### PR TITLE
Rename FooNN to use width instead of range.

### DIFF
--- a/schema/configuration-structure.asn
+++ b/schema/configuration-structure.asn
@@ -3,7 +3,7 @@ DEFINITIONS
    AUTOMATIC TAGS ::=
 BEGIN
    IMPORTS Debug, DebugModule FROM Debug-Extension
-      Range, FlexibleRange, FlexibleRange4, FlexibleRange8, FlexibleRange16 FROM Helper-Types
+      Range, FlexibleRange, FlexibleRange2, FlexibleRange3, FlexibleRange4 FROM Helper-Types
       Tuple, Triple, PossibleValue, PhysicalAddress FROM Helper-Types
       Isa, PrivModes, PrivSatps, Privileged FROM Hart-Extension
       VirtMem FROM Virtual-Memory-Extension
@@ -38,9 +38,9 @@ BEGIN
 
    Hart ::= SEQUENCE {
       hartid CHOICE { /* 4 choices use 2-bit as the index*/
-        hartId4  FlexibleRange4, /* For hart number [1..4] */
-        hartId8  FlexibleRange8, /* For hart number [1..8] */
-        hartId16 FlexibleRange16, /* For hart number [1..16] */
+        hartId4  FlexibleRange2, /* For hart number [1..4] */
+        hartId8  FlexibleRange3, /* For hart number [1..8] */
+        hartId16 FlexibleRange4, /* For hart number [1..16] */
         hartId   FlexibleRange   /* For hart number > 16 */
       },
       debug Debug OPTIONAL,

--- a/schema/helper-types.asn
+++ b/schema/helper-types.asn
@@ -41,7 +41,7 @@ BEGIN
       -- a 2-bit count
       single SEQUENCE SIZE(1..4) OF Integer2 OPTIONAL,
       -- The intenger range is [0..3]
-      range SEQUENCE OF Range2 OPTIONAL
+      range SEQUENCE SIZE(1..2) OF Range2 OPTIONAL
    }
 
    -- 3-bit flexible range [0..7]
@@ -50,7 +50,7 @@ BEGIN
       -- a 3-bit count
       single SEQUENCE SIZE(1..8) OF Integer3 OPTIONAL,
       -- The intenger range is [0..7]
-      range SEQUENCE OF Range3 OPTIONAL
+      range SEQUENCE SIZE(1..4) OF Range3 OPTIONAL
    }
 
    -- 4-bit flexible range [0..15]
@@ -59,7 +59,7 @@ BEGIN
       -- a 4-bit count
       single SEQUENCE SIZE(1..16) OF Integer3 OPTIONAL,
       -- The intenger range is [0..15]
-      range SEQUENCE OF Range4 OPTIONAL
+      range SEQUENCE SIZE(1..8) OF Range4 OPTIONAL
    }
    -- Any size of flexible range
    FlexibleRange ::= SEQUENCE {

--- a/schema/helper-types.asn
+++ b/schema/helper-types.asn
@@ -2,32 +2,32 @@ Helper-Types
 DEFINITIONS
    AUTOMATIC TAGS ::=
 BEGIN
-   EXPORTS FlexibleRange, FlexibleRange4, FlexibleRange8, FlexibleRange16,
+   EXPORTS FlexibleRange, FlexibleRange2, FlexibleRange3, FlexibleRange4,
            Range, Tuple, Triple, PossibleValues;
 
    -- 2-bit integer
-   Integer4 ::= INTEGER (0..3)
+   Integer2 ::= INTEGER (0..3)
 
    -- 3-bit integer
-   Integer8 ::= INTEGER (0..7)
+   Integer3 ::= INTEGER (0..7)
 
    -- 4-bit integer
-   Integer16 ::= INTEGER (0..15)
+   Integer4 ::= INTEGER (0..15)
 
    -- 2-bit integer of range [0..3]
+   Range2 ::= SEQUENCE {
+      start Integer2,
+      length Integer2
+   }
+   -- 3-bit integer of range [0..7]
+   Range3 ::= SEQUENCE {
+      start Integer3,
+      length Integer3
+   }
+   -- 4-bit integer of range [0..15]
    Range4 ::= SEQUENCE {
       start Integer4,
       length Integer4
-   }
-   -- 3-bit integer of range [0..7]
-   Range8 ::= SEQUENCE {
-      start Integer8,
-      length Integer8
-   }
-   -- 4-bit integer of range [0..15]
-   Range16 ::= SEQUENCE {
-      start Integer16,
-      length Integer16
    }
    -- Any size of interger
    Range ::= SEQUENCE {
@@ -36,30 +36,30 @@ BEGIN
    }
 
    -- 2-bit flexible range [0..3]
-   FlexibleRange4 ::= SEQUENCE {
+   FlexibleRange2 ::= SEQUENCE {
       -- The count of single sequence [1..4] which is
       -- a 2-bit count
-      single SEQUENCE SIZE(1..4) OF Integer4 OPTIONAL,
+      single SEQUENCE SIZE(1..4) OF Integer2 OPTIONAL,
       -- The intenger range is [0..3]
-      range SEQUENCE OF Range4 OPTIONAL
+      range SEQUENCE OF Range2 OPTIONAL
    }
 
    -- 3-bit flexible range [0..7]
-   FlexibleRange8 ::= SEQUENCE {
+   FlexibleRange3 ::= SEQUENCE {
       -- The count of single sequence [1..8] which is 
       -- a 3-bit count
-      single SEQUENCE SIZE(1..8) OF Integer8 OPTIONAL,
+      single SEQUENCE SIZE(1..8) OF Integer3 OPTIONAL,
       -- The intenger range is [0..7]
-      range SEQUENCE OF Range8 OPTIONAL
+      range SEQUENCE OF Range3 OPTIONAL
    }
 
    -- 4-bit flexible range [0..15]
-   FlexibleRange16 ::= SEQUENCE {
+   FlexibleRange4 ::= SEQUENCE {
       -- The count of single sequence [1..16] which is
       -- a 4-bit count
-      single SEQUENCE SIZE(1..16) OF Integer8 OPTIONAL,
+      single SEQUENCE SIZE(1..16) OF Integer3 OPTIONAL,
       -- The intenger range is [0..15]
-      range SEQUENCE OF Range16 OPTIONAL
+      range SEQUENCE OF Range4 OPTIONAL
    }
    -- Any size of flexible range
    FlexibleRange ::= SEQUENCE {


### PR DESCRIPTION
Now Integer4 represents a 4-bit integer, which eliminates Integer16 used
to refer to a 4-bit integer. (My programmer brain sees Integer16 and
parses it as a 16-bit integer, and I assume other people will make the
same association.)