### PR TITLE
Change sequence of choices to optional members.

### DIFF
--- a/examples/example.jer
+++ b/examples/example.jer
@@ -8,107 +8,103 @@
                     ]
                 }
             },
-            "extension": [
-                {
-                    "debug": {
-                        "trigger": [
-                            {
-                                "index" : {
-                                    "range": [
-                                        {
-                                            "start": 0,
-                                            "length": 3
-                                         }
-                                    ]
-                                },
-                                "mcontrol": [
-                                    {
-                                        "maskmax": 4,
-                                        "hit": false,
-                                        "addressMatch": false,
-                                        "dataMatch": true,
-                                        "timingBefore": true,
-                                        "timingAfter": false,
-                                        "sizeAny": true,
-                                        "sizeS8": false,
-                                        "sizeS16": false,
-                                        "sizeS32": false,
-                                        "sizeS64": false,
-                                        "sizeS80": false,
-                                        "sizeS96": false,
-                                        "sizeS112": false,
-                                        "sizeS128": false,
-                                        "matchEqual": true,
-                                        "matchNapot": true,
-                                        "matchGreaterEqual": true,
-                                        "matchLess": true,
-                                        "matchLowMask": false,
-                                        "matchHighMask": false,
-                                        "matchNotEqual": false,
-                                        "matchNotNapot": false,
-                                        "matchNotLowMask": false,
-                                        "matchNotHighMask": false,
-                                        "actionMmode": true,
-                                        "actionDmode": true,
-                                        "chain": false,
-                                        "m": true,
-                                        "u": true,
-                                        "s": false,
-                                        "execute": true,
-                                        "store": true,
-                                        "load": true
+            "debug": {
+                "trigger": [
+                    {
+                        "index" : {
+                            "range": [
+                                {
+                                    "start": 0,
+                                    "length": 3
                                     }
-                                ]
-                            },
+                            ]
+                        },
+                        "mcontrol": [
                             {
-                                "index": {
-                                    "single": [
-                                        4
-                                    ]
-                                },
-                                "mcontrol": [
-                                    {
-                                        "maskmax": 4,
-                                        "hit": false,
-                                        "addressMatch": false,
-                                        "sizeAny": true,
-                                        "sizeS8": false,
-                                        "sizeS16": false,
-                                        "sizeS32": false,
-                                        "sizeS64": false,
-                                        "sizeS80": false,
-                                        "sizeS96": false,
-                                        "sizeS112": false,
-                                        "sizeS128": false,
-                                        "dataMatch": true,
-                                        "timingBefore": true,
-                                        "timingAfter": false,
-                                        "matchEqual": true,
-                                        "matchNapot": true,
-                                        "matchGreaterEqual": true,
-                                        "matchLess": true,
-                                        "matchLowMask": false,
-                                        "matchHighMask": false,
-                                        "matchNotEqual": false,
-                                        "matchNotNapot": false,
-                                        "matchNotLowMask": false,
-                                        "matchNotHighMask": false,
-                                        "actionMmode": true,
-                                        "actionDmode": true,
-                                        "chain": false,
-                                        "m": true,
-                                        "s": true,
-                                        "u": true,
-                                        "execute": true,
-                                        "store": true,
-                                        "load": true
-                                    }
-                                ]
+                                "maskmax": 4,
+                                "hit": false,
+                                "addressMatch": false,
+                                "dataMatch": true,
+                                "timingBefore": true,
+                                "timingAfter": false,
+                                "sizeAny": true,
+                                "sizeS8": false,
+                                "sizeS16": false,
+                                "sizeS32": false,
+                                "sizeS64": false,
+                                "sizeS80": false,
+                                "sizeS96": false,
+                                "sizeS112": false,
+                                "sizeS128": false,
+                                "matchEqual": true,
+                                "matchNapot": true,
+                                "matchGreaterEqual": true,
+                                "matchLess": true,
+                                "matchLowMask": false,
+                                "matchHighMask": false,
+                                "matchNotEqual": false,
+                                "matchNotNapot": false,
+                                "matchNotLowMask": false,
+                                "matchNotHighMask": false,
+                                "actionMmode": true,
+                                "actionDmode": true,
+                                "chain": false,
+                                "m": true,
+                                "u": true,
+                                "s": false,
+                                "execute": true,
+                                "store": true,
+                                "load": true
+                            }
+                        ]
+                    },
+                    {
+                        "index": {
+                            "single": [
+                                4
+                            ]
+                        },
+                        "mcontrol": [
+                            {
+                                "maskmax": 4,
+                                "hit": false,
+                                "addressMatch": false,
+                                "sizeAny": true,
+                                "sizeS8": false,
+                                "sizeS16": false,
+                                "sizeS32": false,
+                                "sizeS64": false,
+                                "sizeS80": false,
+                                "sizeS96": false,
+                                "sizeS112": false,
+                                "sizeS128": false,
+                                "dataMatch": true,
+                                "timingBefore": true,
+                                "timingAfter": false,
+                                "matchEqual": true,
+                                "matchNapot": true,
+                                "matchGreaterEqual": true,
+                                "matchLess": true,
+                                "matchLowMask": false,
+                                "matchHighMask": false,
+                                "matchNotEqual": false,
+                                "matchNotNapot": false,
+                                "matchNotLowMask": false,
+                                "matchNotHighMask": false,
+                                "actionMmode": true,
+                                "actionDmode": true,
+                                "chain": false,
+                                "m": true,
+                                "s": true,
+                                "u": true,
+                                "execute": true,
+                                "store": true,
+                                "load": true
                             }
                         ]
                     }
-                }
-            ]
+                ]
+            }
         },
         {
             "hartid": {
@@ -121,59 +117,55 @@
                     ]
                 }
             },
-            "extension": [
-                {
-                    "debug": {
-                        "trigger": [
+            "debug": {
+                "trigger": [
+                    {
+                        "index": {
+                            "single": [
+                                4
+                            ]
+                        },
+                        "mcontrol": [
                             {
-                                "index": {
-                                    "single": [
-                                        4
-                                    ]
-                                },
-                                "mcontrol": [
-                                    {
-                                        "maskmax": 4,
-                                        "hit": false,
-                                        "sizeAny": true,
-                                        "sizeS8": false,
-                                        "sizeS16": false,
-                                        "sizeS32": false,
-                                        "sizeS64": false,
-                                        "sizeS80": false,
-                                        "sizeS96": false,
-                                        "sizeS112": false,
-                                        "sizeS128": false,
-                                        "addressMatch": false,
-                                        "dataMatch": true,
-                                        "timingBefore": true,
-                                        "timingAfter": false,
-                                        "matchEqual": true,
-                                        "matchNapot": true,
-                                        "matchGreaterEqual": true,
-                                        "matchLess": true,
-                                        "matchLowMask": false,
-                                        "matchHighMask": false,
-                                        "matchNotEqual": false,
-                                        "matchNotNapot": false,
-                                        "matchNotLowMask": false,
-                                        "matchNotHighMask": false,
-                                        "actionMmode": true,
-                                        "actionDmode": true,
-                                        "chain": false,
-                                        "m": true,
-                                        "s": true,
-                                        "u": true,
-                                        "execute": true,
-                                        "store": true,
-                                        "load": true
-                                    }
-                                ]
+                                "maskmax": 4,
+                                "hit": false,
+                                "sizeAny": true,
+                                "sizeS8": false,
+                                "sizeS16": false,
+                                "sizeS32": false,
+                                "sizeS64": false,
+                                "sizeS80": false,
+                                "sizeS96": false,
+                                "sizeS112": false,
+                                "sizeS128": false,
+                                "addressMatch": false,
+                                "dataMatch": true,
+                                "timingBefore": true,
+                                "timingAfter": false,
+                                "matchEqual": true,
+                                "matchNapot": true,
+                                "matchGreaterEqual": true,
+                                "matchLess": true,
+                                "matchLowMask": false,
+                                "matchHighMask": false,
+                                "matchNotEqual": false,
+                                "matchNotNapot": false,
+                                "matchNotLowMask": false,
+                                "matchNotHighMask": false,
+                                "actionMmode": true,
+                                "actionDmode": true,
+                                "chain": false,
+                                "m": true,
+                                "s": true,
+                                "u": true,
+                                "execute": true,
+                                "store": true,
+                                "load": true
                             }
                         ]
                     }
-                }
-            ]
+                ]
+            }
         },
         {
             "hartid": {
@@ -185,31 +177,25 @@
                     ]
                 }
             },
-            "extension": [
-                {
-                    "isa": {
-                        "riscv32": true,
-                        "riscv64": true
-                    }
+            "isa": {
+                "riscv32": true,
+                "riscv64": true
+            },
+            "privileged": {
+                "modes": {
+                    "m": true,
+                    "s": true,
+                    "u": true
                 },
-                {
-                    "privileged": {
-                        "modes": {
-                            "m": true,
-                            "s": true,
-                            "u": true
-                        },
-                        "epmp": true,
-                        "satps": {
-                            "sv32": false,
-                            "sv39": true,
-                            "sv48": true,
-                            "sv57": true,
-                            "sv64": true
-                        }
-                    }
+                "epmp": true,
+                "satps": {
+                    "sv32": false,
+                    "sv39": true,
+                    "sv48": true,
+                    "sv57": true,
+                    "sv64": true
                 }
-            ]
+            }
         },
         {
             "hartid": {
@@ -220,30 +206,24 @@
                     ]
                 }
             },
-            "extension": [
-                {
-                    "isa": {
-                        "riscv64": true
-                    }
+            "isa": {
+                "riscv64": true
+            },
+            "privileged": {
+                "modes": {
+                    "u": false,
+                    "m": true,
+                    "s": false
                 },
-                {
-                    "privileged": {
-                        "modes": {
-                            "u": false,
-                            "m": true,
-                            "s": false
-                        },
-                        "epmp": true,
-                        "satps": {
-                            "sv32": false,
-                            "sv39": false,
-                            "sv48": false,
-                            "sv57": false,
-                            "sv64": false
-                        }
-                    }
+                "epmp": true,
+                "satps": {
+                    "sv32": false,
+                    "sv39": false,
+                    "sv48": false,
+                    "sv57": false,
+                    "sv64": false
                 }
-            ]
+            }
         },
         {
             "hartid": {
@@ -256,14 +236,10 @@
                     ]
                 }
             },
-            "extension": [
-                {
-                    "fastInt": {
-                        "mModeTimeRegAddr": 4660,
-                        "mModeTimeCompRegAddr": 4660
-                    }
-                }
-            ]
+            "fastInt": {
+                "mModeTimeRegAddr": 4660,
+                "mModeTimeCompRegAddr": 4660
+            }
         }
     ],
     "debugModule": [

--- a/schema.asn
+++ b/schema.asn
@@ -61,14 +61,6 @@ Configuration-Structure-Schema DEFINITIONS AUTOMATIC TAGS ::= BEGIN
       single SEQUENCE OF INTEGER OPTIONAL,
       range SEQUENCE OF Range OPTIONAL
    }
-   HartExtension ::= CHOICE {
-         debug Debug,
-         isa Isa,
-         privileged Privileged,
-         clic Clic,
-         fastInt FastInt,
-         ...
-   }
    Hart ::= SEQUENCE {
       hartid CHOICE { /* 4 choices use 2-bit as the index*/
         hartId4  FlexibleRange4, /* For hart number [1..4] */
@@ -76,7 +68,11 @@ Configuration-Structure-Schema DEFINITIONS AUTOMATIC TAGS ::= BEGIN
         hartId16 FlexibleRange8, /* For hart number [1..16] */
         hartId   FlexibleRange   /* For hart number > 16 */
       },
-      extension SEQUENCE OF HartExtension OPTIONAL,
+      debug Debug OPTIONAL,
+      isa Isa OPTIONAL,
+      privileged Privileged OPTIONAL,
+      clic Clic OPTIONAL,
+      fastInt FastInt OPTIONAL,
       ...
    }
    Tuple ::= SEQUENCE {


### PR DESCRIPTION
When I first ran this experiment I didn't realize how extension markers
really worked, and I concluded erroneously that there was a significant
benefit to using a sequence of choices.

In a new test I used the extension markers properly, which gets rid of
the huge difference between adding a new choice vs. adding a new
optional member to a type. To test, I created 100 extensions, and then
used some subset of those in a real example. The results are:
Number used	Optional size	Choice size
0       	84      	90
1       	106     	100
2       	115     	110
3       	124     	120
4       	133     	130
5       	142     	140
6       	151     	150
7       	160     	161
8       	169     	172
9       	178     	183
10      	187     	195
20      	277	        298

As you can see using optional members ("optional size") is generally
smaller, except when there are between 1 and 6 extensions used. Even
then the largest difference is 5 bytes.

Size aside, using optional members makes the code (both schema and
description) slightly shorter and easier to read.

examples/debug_module.jer is 16B in UPER
examples/example.jer is 84B in UPER