### PR TITLE
Flesh out Debug section

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,9 +1,9 @@
 name: Schema/Example Test
 on: [push]
 jobs:
-    Explore-GitHub-Actions:
+    Test-Examples:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - run: pip install asn1tools
+            - run: pip install asn1tools deepdiff
             - run: make test

--- a/examples/debug_module.jer
+++ b/examples/debug_module.jer
@@ -1,12 +1,12 @@
 {
     "debugModule": [
         {
+            "runControl": {
+            },
             "abstract": {
                 "accessRegister": [
                     {
-                        "aarsize32": false,
-                        "aarsize64": true,
-                        "aarsize128": true,
+                        "aarsize": ["s64", "s128"],
                         "aarpostincrementSupported": false,
                         "postexecSupported": true,
                         "regno": {

--- a/examples/debug_module.jer
+++ b/examples/debug_module.jer
@@ -1,12 +1,11 @@
 {
     "debugModule": [
         {
-            "runControl": {
-            },
             "abstract": {
                 "accessRegister": [
                     {
-                        "aarsize": ["s64", "s128"],
+                        "aarsize64Supported": true,
+                        "aarsize128Supported": true,
                         "aarpostincrementSupported": false,
                         "postexecSupported": true,
                         "regno": {
@@ -27,6 +26,8 @@
                             "length": 4
                     }
                 ]
+            },
+            "runControl": {
             }
         }
     ]

--- a/examples/example.jer
+++ b/examples/example.jer
@@ -19,87 +19,48 @@
                                     }
                             ]
                         },
+                        "actionSupported": {
+                                "breakpointExceptionSupported": true,
+                                "debugModeSupported": true
+                        },
                         "mcontrol": [
                             {
                                 "maskmax": 4,
-                                "hit": false,
-                                "addressMatch": false,
-                                "dataMatch": true,
-                                "timingBefore": true,
-                                "timingAfter": false,
+                                "selectSupported": "data",
+                                "timingSupported": "before",
                                 "sizeAny": true,
-                                "sizeS8": false,
-                                "sizeS16": false,
-                                "sizeS32": false,
-                                "sizeS64": false,
-                                "sizeS80": false,
-                                "sizeS96": false,
-                                "sizeS112": false,
-                                "sizeS128": false,
                                 "matchEqual": true,
                                 "matchNapot": true,
                                 "matchGreaterEqual": true,
                                 "matchLess": true,
-                                "matchLowMask": false,
-                                "matchHighMask": false,
-                                "matchNotEqual": false,
-                                "matchNotNapot": false,
-                                "matchNotLowMask": false,
-                                "matchNotHighMask": false,
-                                "actionMmode": true,
-                                "actionDmode": true,
-                                "chain": false,
-                                "m": true,
-                                "u": true,
-                                "s": false,
-                                "execute": true,
-                                "store": true,
-                                "load": true
+                                "executeSupported": true,
+                                "storeSupported": true,
+                                "loadSupported": true
                             }
                         ]
                     },
                     {
                         "index": {
-                            "single": [
-                                4
-                            ]
+                            "single": [ 4 ]
+                        },
+                        "actionSupported": {
+                                "breakpointExceptionSupported": true,
+                                "debugModeSupported": true
                         },
                         "mcontrol": [
                             {
                                 "maskmax": 4,
-                                "hit": false,
-                                "addressMatch": false,
+                                "selectSupported": "address",
                                 "sizeAny": true,
-                                "sizeS8": false,
-                                "sizeS16": false,
-                                "sizeS32": false,
-                                "sizeS64": false,
-                                "sizeS80": false,
-                                "sizeS96": false,
-                                "sizeS112": false,
-                                "sizeS128": false,
                                 "dataMatch": true,
-                                "timingBefore": true,
-                                "timingAfter": false,
+                                "timingSupported": "before",
                                 "matchEqual": true,
                                 "matchNapot": true,
                                 "matchGreaterEqual": true,
                                 "matchLess": true,
-                                "matchLowMask": false,
-                                "matchHighMask": false,
-                                "matchNotEqual": false,
-                                "matchNotNapot": false,
-                                "matchNotLowMask": false,
-                                "matchNotHighMask": false,
-                                "actionMmode": true,
-                                "actionDmode": true,
-                                "chain": false,
-                                "m": true,
-                                "s": true,
-                                "u": true,
-                                "execute": true,
-                                "store": true,
-                                "load": true
+                                "executeSupported": true,
+                                "storeSupported": true,
+                                "loadSupported": true
                             }
                         ]
                     }
@@ -125,42 +86,23 @@
                                 4
                             ]
                         },
+                        "actionSupported": {
+                                "breakpointExceptionSupported": true,
+                                "debugModeSupported": true
+                        },
                         "mcontrol": [
                             {
                                 "maskmax": 4,
-                                "hit": false,
                                 "sizeAny": true,
-                                "sizeS8": false,
-                                "sizeS16": false,
-                                "sizeS32": false,
-                                "sizeS64": false,
-                                "sizeS80": false,
-                                "sizeS96": false,
-                                "sizeS112": false,
-                                "sizeS128": false,
-                                "addressMatch": false,
-                                "dataMatch": true,
-                                "timingBefore": true,
-                                "timingAfter": false,
+                                "selectSupported": "data",
+                                "timingSupported": "before",
                                 "matchEqual": true,
                                 "matchNapot": true,
                                 "matchGreaterEqual": true,
                                 "matchLess": true,
-                                "matchLowMask": false,
-                                "matchHighMask": false,
-                                "matchNotEqual": false,
-                                "matchNotNapot": false,
-                                "matchNotLowMask": false,
-                                "matchNotHighMask": false,
-                                "actionMmode": true,
-                                "actionDmode": true,
-                                "chain": false,
-                                "m": true,
-                                "s": true,
-                                "u": true,
-                                "execute": true,
-                                "store": true,
-                                "load": true
+                                "executeSupported": true,
+                                "storeSupported": true,
+                                "loadSupported": true
                             }
                         ]
                     }
@@ -247,10 +189,8 @@
             "abstract": {
                 "accessRegister": [
                     {
-                        "aarsize32": false,
-                        "aarsize64": true,
-                        "aarsize128": true,
-                        "aarpostincrementSupported": false,
+                        "aarsize64Supported": true,
+                        "aarsize128Supported": true,
                         "postexecSupported": true,
                         "regno": {
                             "range" : [
@@ -270,6 +210,8 @@
                             "length": 4
                     }
                 ]
+            },
+            "runControl": {
             }
         }
     ],

--- a/schema.asn
+++ b/schema.asn
@@ -171,29 +171,82 @@ BEGIN
    EXPORTS Debug, DebugModule;
    IMPORTS FlexibleRange FROM Helper-Types;
 
-   TriggerAction ::= BIT STRING {
-      breakpointException(0), debugMode(1),
+   TriggerAction ::= SEQUENCE {
+      breakpointExceptionSupported BOOLEAN DEFAULT FALSE,
+      debugModeSupported BOOLEAN DEFAULT FALSE,
       -- TODO: Add trace actions
-      external0(2), external1(3)
+      external0Supported BOOLEAN DEFAULT FALSE,
+      external1Supported BOOLEAN DEFAULT FALSE,
+      ...
+   }
+
+   TriggerModes ::= SEQUENCE {
+      m BOOLEAN DEFAULT FALSE,
+      s BOOLEAN DEFAULT FALSE,
+      u BOOLEAN DEFAULT FALSE,
+      vs BOOLEAN DEFAULT FALSE,
+      vu BOOLEAN DEFAULT FALSE,
+      ...
    }
 
    TriggerMcontrol ::= SEQUENCE {
-      -- Describes both mcontrol and mcontrol6 type triggers, so include the
-      -- type.
-      type ENUMERATED {mcontrol, mcontrol6},
       maskmax INTEGER (0..63),
       selectSupported ENUMERATED {address, data, both},
       timingSupported ENUMERATED {before, after, both},
       addressMatch BOOLEAN DEFAULT FALSE,
       dataMatch BOOLEAN DEFAULT FALSE,
-      sizeSupported BIT STRING {
-         any(0), b8(1), b16(2), b32(3), b64(4), b80(5), b96(6), b112(7), b128(8)
-      },
+      sizeAny BOOLEAN DEFAULT FALSE,
+      size8 BOOLEAN DEFAULT FALSE,
+      size16 BOOLEAN DEFAULT FALSE,
+      size32 BOOLEAN DEFAULT FALSE,
+      size64 BOOLEAN DEFAULT FALSE,
+      size80 BOOLEAN DEFAULT FALSE,
+      size96 BOOLEAN DEFAULT FALSE,
+      size112 BOOLEAN DEFAULT FALSE,
+      size128 BOOLEAN DEFAULT FALSE,
       chainSupported BOOLEAN DEFAULT FALSE,
-      matchesSupported BIT STRING {
-         equal(0), napot(1), greaterEqual(2), less(3), lowMask(4), highMask(5),
-         notEqual(6), notNapot(7), notLowMask(8), notHighMask(9)
-      },
+      matchEqual BOOLEAN DEFAULT FALSE,
+      matchNapot BOOLEAN DEFAULT FALSE,
+      matchGreaterEqual BOOLEAN DEFAULT FALSE,
+      matchLess BOOLEAN DEFAULT FALSE,
+      matchLowMask BOOLEAN DEFAULT FALSE,
+      matchHighMask BOOLEAN DEFAULT FALSE,
+      matchNotEqual BOOLEAN DEFAULT FALSE,
+      matchNotNapot BOOLEAN DEFAULT FALSE,
+      matchNotLowMask BOOLEAN DEFAULT FALSE,
+      matchNotHighMask BOOLEAN DEFAULT FALSE,
+      executeSupported BOOLEAN DEFAULT FALSE,
+      storeSupported BOOLEAN DEFAULT FALSE,
+      loadSupported BOOLEAN DEFAULT FALSE,
+      ...
+   }
+
+   TriggerMcontrol6 ::= SEQUENCE {
+      maskmax INTEGER (0..63),
+      selectSupported ENUMERATED {address, data, both},
+      timingSupported ENUMERATED {before, after, both},
+      addressMatch BOOLEAN DEFAULT FALSE,
+      dataMatch BOOLEAN DEFAULT FALSE,
+      sizeAny BOOLEAN DEFAULT FALSE,
+      size8 BOOLEAN DEFAULT FALSE,
+      size16 BOOLEAN DEFAULT FALSE,
+      size32 BOOLEAN DEFAULT FALSE,
+      size64 BOOLEAN DEFAULT FALSE,
+      size80 BOOLEAN DEFAULT FALSE,
+      size96 BOOLEAN DEFAULT FALSE,
+      size112 BOOLEAN DEFAULT FALSE,
+      size128 BOOLEAN DEFAULT FALSE,
+      chainSupported BOOLEAN DEFAULT FALSE,
+      matchEqual BOOLEAN DEFAULT FALSE,
+      matchNapot BOOLEAN DEFAULT FALSE,
+      matchGreaterEqual BOOLEAN DEFAULT FALSE,
+      matchLess BOOLEAN DEFAULT FALSE,
+      matchLowMask BOOLEAN DEFAULT FALSE,
+      matchHighMask BOOLEAN DEFAULT FALSE,
+      matchNotEqual BOOLEAN DEFAULT FALSE,
+      matchNotNapot BOOLEAN DEFAULT FALSE,
+      matchNotLowMask BOOLEAN DEFAULT FALSE,
+      matchNotHighMask BOOLEAN DEFAULT FALSE,
       executeSupported BOOLEAN DEFAULT FALSE,
       storeSupported BOOLEAN DEFAULT FALSE,
       loadSupported BOOLEAN DEFAULT FALSE,
@@ -233,14 +286,12 @@ BEGIN
       -- to the trigger, but that would be a very strange implementation.
       hitSupported BOOLEAN DEFAULT FALSE,
       actionSupported TriggerAction,
-      -- TODO: Do we need to list which modes are supported? Might there be
-      -- implementations that support execution modes but not hardware triggers
-      -- in those execution modes?
+      -- If TriggerModes is not supplied, it is assumed that the triggers
+      -- support every mode that the hart supports.
+      modeSupported TriggerModes OPTIONAL,
 
-      -- TODO: Do we need to replicate TriggerAction in every instance of every
-      -- trigger? That seems wasteful in size, and really what implementation
-      -- would have different actions for different triggers?
       mcontrol SEQUENCE OF TriggerMcontrol OPTIONAL,
+      mcontrol6 SEQUENCE OF TriggerMcontrol6 OPTIONAL,
       icount SEQUENCE OF TriggerIcount OPTIONAL,
       itrigger SEQUENCE OF TriggerItrigger OPTIONAL,
       etrigger SEQUENCE OF TriggerEtrigger OPTIONAL,
@@ -262,6 +313,8 @@ BEGIN
    }
 
    AccessRegisterCommand ::= SEQUENCE {
+      -- I'd like to use a BIT STRING for the size, but JER format doesn't let
+      -- you use symbolic names for them.
       aarsize32Supported BOOLEAN DEFAULT FALSE,
       aarsize64Supported BOOLEAN DEFAULT FALSE,
       aarsize128Supported BOOLEAN DEFAULT FALSE,

--- a/schema.asn
+++ b/schema.asn
@@ -182,51 +182,31 @@ BEGIN
       -- type.
       type ENUMERATED {mcontrol, mcontrol6},
       maskmax INTEGER (0..63),
-      vsSupported BOOLEAN,
-      vuSupported BOOLEAN,
-      hitSupported BOOLEAN,
       selectSupported ENUMERATED {address, data, both},
       timingSupported ENUMERATED {before, after, both},
-      addressMatch BOOLEAN,
-      dataMatch BOOLEAN,
+      addressMatch BOOLEAN DEFAULT FALSE,
+      dataMatch BOOLEAN DEFAULT FALSE,
       sizeSupported BIT STRING {
          any(0), b8(1), b16(2), b32(3), b64(4), b80(5), b96(6), b112(7), b128(8)
       },
-      actionSupported TriggerAction,
-      chainSupported BOOLEAN,
+      chainSupported BOOLEAN DEFAULT FALSE,
       matchesSupported BIT STRING {
          equal(0), napot(1), greaterEqual(2), less(3), lowMask(4), highMask(5),
          notEqual(6), notNapot(7), notLowMask(8), notHighMask(9)
       },
-      mSupported BOOLEAN,
-      sSupported BOOLEAN,
-      uSupported BOOLEAN,
-      executeSupported BOOLEAN,
-      storeSupported BOOLEAN,
-      loadSupported BOOLEAN,
+      executeSupported BOOLEAN DEFAULT FALSE,
+      storeSupported BOOLEAN DEFAULT FALSE,
+      loadSupported BOOLEAN DEFAULT FALSE,
       ...
    }
 
    TriggerIcount ::= SEQUENCE {
-      vsSupported BOOLEAN,
-      vuSupported BOOLEAN,
-      hitSupported BOOLEAN,
       countMax INTEGER (1..16383),
-      mSupported BOOLEAN,
-      sSupported BOOLEAN,
-      uSupported BOOLEAN,
-      actionSupported TriggerAction,
       ...
    }
 
    TriggerItrigger ::= SEQUENCE {
-      hitSupported BOOLEAN,
-      vsSupported BOOLEAN,
-      vuSupported BOOLEAN,
-      mSupported BOOLEAN,
-      sSupported BOOLEAN,
-      uSupported BOOLEAN,
-      actionSupported TriggerAction,
+      supported NULL,
       -- Intentionally not describing possible tdata2 values. TODO: Should we?
       -- Certainly it's an implementation decision which interrupts we can
       -- trigger on, but it's fairly easy to discover which values are valid.
@@ -235,27 +215,28 @@ BEGIN
    }
 
    TriggerEtrigger ::= SEQUENCE {
-      hitSupported BOOLEAN,
-      vsSupported BOOLEAN,
-      vuSupported BOOLEAN,
       nmiSupported BOOLEAN,
-      mSupported BOOLEAN,
-      sSupported BOOLEAN,
-      uSupported BOOLEAN,
-      actionSupported TriggerAction,
       ...
    }
 
    TriggerTmexttrigger ::= SEQUENCE {
-      hitSupported BOOLEAN,
       intctlSupported BOOLEAN,
       selectSupported BIT STRING, -- TODO: Constrain length
-      actionSupported TriggerAction,
       ...
    }
 
    DebugTrigger ::= SEQUENCE {
+      -- Which triggers does this description apply to?
       index FlexibleRange,
+
+      -- Technically these could differ depending on the precise arguments given
+      -- to the trigger, but that would be a very strange implementation.
+      hitSupported BOOLEAN DEFAULT FALSE,
+      actionSupported TriggerAction,
+      -- TODO: Do we need to list which modes are supported? Might there be
+      -- implementations that support execution modes but not hardware triggers
+      -- in those execution modes?
+
       -- TODO: Do we need to replicate TriggerAction in every instance of every
       -- trigger? That seems wasteful in size, and really what implementation
       -- would have different actions for different triggers?
@@ -267,109 +248,94 @@ BEGIN
    }
 
    ContextInfo ::= SEQUENCE {
-      tcontrol SEQUENCE {
-         hcxeSupported BOOLEAN,
-         scxeSupported BOOLEAN,
-         mpteSupported BOOLEAN,
-         mteSupported BOOLEAN,
-         ...
-      },
-      hcontextSupported BOOLEAN,
-      scontextSupported BOOLEAN,
-      mcontextSupported BOOLEAN,
+      -- Keep this in its own section which is optional, since tiny cores won't
+      -- have any of these modes, and can then encode in a single bit they have
+      -- none of this.
+      hcxeSupported BOOLEAN DEFAULT FALSE,
+      scxeSupported BOOLEAN DEFAULT FALSE,
+      mpteSupported BOOLEAN DEFAULT FALSE,
+      mteSupported BOOLEAN DEFAULT FALSE,
+      hcontextSupported BOOLEAN DEFAULT FALSE,
+      scontextSupported BOOLEAN DEFAULT FALSE,
+      mcontextSupported BOOLEAN DEFAULT FALSE,
       ...
    }
 
    AccessRegisterCommand ::= SEQUENCE {
-      aarsize BIT STRING {s32 (0), s64(1), s128(2)},
-      aarpostincrementSupported BOOLEAN,
-      postexecSupported BOOLEAN,
+      aarsize32Supported BOOLEAN DEFAULT FALSE,
+      aarsize64Supported BOOLEAN DEFAULT FALSE,
+      aarsize128Supported BOOLEAN DEFAULT FALSE,
+      aarpostincrementSupported BOOLEAN DEFAULT FALSE,
+      postexecSupported BOOLEAN DEFAULT FALSE,
       regno FlexibleRange,
       ...
    }
    
    QuickAccessCommand ::= SEQUENCE {
-      supported BOOLEAN,
+      -- A SEQUENCE cannot be empty, so we have to put something in here. NULL
+      -- takes no space to encode.
+      supported NULL,
       ...
    }
 
    AccessMemoryCommand ::= SEQUENCE {
-      aamvirtual0 BOOLEAN,
-      aamvirtual1 BOOLEAN,
-      aamsize8 BOOLEAN,
-      aamsize16 BOOLEAN,
-      aamsize32 BOOLEAN,
-      aamsize64 BOOLEAN,
-      aamsize128 BOOLEAN,
-      aampostincrementSupported BOOLEAN,
-      writeSupported BOOLEAN,
-      readSupported BOOLEAN,
+      aamvirtual0 BOOLEAN DEFAULT FALSE,
+      aamvirtual1 BOOLEAN DEFAULT FALSE,
+      aamsize8 BOOLEAN DEFAULT FALSE,
+      aamsize16 BOOLEAN DEFAULT FALSE,
+      aamsize32 BOOLEAN DEFAULT FALSE,
+      aamsize64 BOOLEAN DEFAULT FALSE,
+      aamsize128 BOOLEAN DEFAULT FALSE,
+      aampostincrementSupported BOOLEAN DEFAULT FALSE,
+      writeSupported BOOLEAN DEFAULT FALSE,
+      readSupported BOOLEAN DEFAULT FALSE,
       ...
    }
 
-   AbstractCommand ::= SEQUENCE {
+   -- Configuration information regarding basic run control, selecting harts,
+   -- reset, etc.
+   RunControl ::= SEQUENCE {
+      hartresetSupported BOOLEAN DEFAULT FALSE,
+      -- If hartselLen is 0, hasel is tied to 0.
+      hartselLen INTEGER (0..20) DEFAULT 0,
+      keepaliveSupported BOOLEAN DEFAULT FALSE,
+      resethaltreqSuported BOOLEAN DEFAULT FALSE,
+      haltGroupCount INTEGER (1..31) OPTIONAL,
+      resumeGroupCount INTEGER (1..31) OPTIONAL,
+      ...
+   }
+
+   -- Configuration information regarding abstract commands.
+   Abstract ::= SEQUENCE {
+      relaxedprivSupported BOOLEAN DEFAULT FALSE,
+      -- We want this to be variable length, because usually only a few low bits
+      -- will be set. I'd like to constrain the length so people cannot specify
+      -- something non-sensical.
+      autoexecprogbuf BIT STRING DEFAULT ''B, -- TODO: Constrain length to 16 bits
+      autoexecdata BIT STRING DEFAULT ''B, -- TODO: Constrain length to 12 bits
+
       -- Enumerate every supported abstract command. It is not required to list
       -- AccessRegisterCommand for the GPRs since that functionality is required
       -- by the spec.
       accessRegister SEQUENCE OF AccessRegisterCommand OPTIONAL,
       quickAccess SEQUENCE OF QuickAccessCommand OPTIONAL,
       accessMemory SEQUENCE OF AccessMemoryCommand OPTIONAL,
-      ...
-   }
 
-   DmControl ::= SEQUENCE {
-      hartresetSupported BOOLEAN,
-      -- If hartselLen is 0, hasel is tied to 0.
-      hartselLen INTEGER (0..20),
-      keepaliveSupported BOOLEAN,
-      resethaltreqSuported BOOLEAN,
-      ...
-   }
-
-   HartInfo ::= SEQUENCE {
-      -- TODO: These are simple read-only fields in the hardware. Do they need
-      -- to be here?
-      nscratch INTEGER (0..15),
-      datasize INTEGER (0..15),
-      -- The choice picked here indicates the value of dataaccess.
-      dataaddr CHOICE {
-         csr INTEGER (0..4095),
-         address INTEGER (-2048 .. 2047)
-      },
-      ...
-   }
-
-   AbstractCs ::= SEQUENCE {
-      relaxedprivSupported BOOLEAN,
-      ...
-   }
-
-   AbstractAuto ::= SEQUENCE {
-      autoexecprogbuf BIT STRING, -- TODO: Constrain length to 16 bits
-      autoexecdata BIT STRING, -- TODO: Constrain length to 12 bits
-      ...
-   }
-
-   SystemBus ::= SEQUENCE {
-      accessSizes BIT STRING {s8 (0), s16 (1), s32 (2), s64 (3), s128 (4)},
       ...
    }
 
    DebugModule ::= SEQUENCE {
+      -- Where this DM is in the chain of DMs. Will almost always be 0.
+      index INTEGER DEFAULT 0,
+      -- Which harts are connected to this DM, identified by hart ID.
+      connectedHarts FlexibleRange OPTIONAL,
+
       -- DMI address of this debug module. Will almost always be 0, in which
       -- case it can be omitted.
       dmiAddress INTEGER DEFAULT 0,
 
-      mcontrol DmControl,
-      hartinfo HartInfo,
-      abstractcs AbstractCs,
-
-      haltGroupCount INTEGER (1..31) OPTIONAL,
-      resumeGroupCount INTEGER (1..31) OPTIONAL,
-
-      index INTEGER OPTIONAL,
-      abstract AbstractCommand,
-      connectedHarts FlexibleRange OPTIONAL,
+      abstract Abstract,
+      runControl RunControl,
       ...
    }
 

--- a/schema.asn
+++ b/schema.asn
@@ -1,4 +1,105 @@
-Configuration-Structure-Schema DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+Configuration-Structure
+DEFINITIONS
+   AUTOMATIC TAGS ::=
+BEGIN
+   IMPORTS Debug, DebugModule FROM Debug-Extension
+         Range, FlexibleRange, FlexibleRange4, FlexibleRange8, FlexibleRange16
+               FROM Helper-Types;
+
+   Hart ::= SEQUENCE {
+      hartid CHOICE { /* 4 choices use 2-bit as the index*/
+        hartId4  FlexibleRange4, /* For hart number [1..4] */
+        hartId8  FlexibleRange8, /* For hart number [1..8] */
+        hartId16 FlexibleRange16, /* For hart number [1..16] */
+        hartId   FlexibleRange   /* For hart number > 16 */
+      },
+      debug Debug OPTIONAL,
+      isa Isa OPTIONAL,
+      privileged Privileged OPTIONAL,
+      clic Clic OPTIONAL,
+      fastInt FastInt OPTIONAL,
+      ...
+   }
+   Tuple ::= SEQUENCE {
+      value INTEGER,
+      mask INTEGER
+   }
+   Triple ::= SEQUENCE {
+      low INTEGER,
+      high INTEGER,
+      mask INTEGER
+   }
+   PossibleValues ::= SEQUENCE {
+      tuple SEQUENCE OF Tuple OPTIONAL,
+      triple SEQUENCE OF Triple OPTIONAL,
+      ...
+   }
+   Configuration ::= SEQUENCE {
+      harts SEQUENCE OF Hart OPTIONAL,
+      debugModule SEQUENCE OF DebugModule OPTIONAL,
+      traceModule TraceModule OPTIONAL,
+      physicalMemory SEQUENCE OF PhysicalMemory OPTIONAL,
+      ...
+   }
+   Isa ::= SEQUENCE {
+      riscv32 BOOLEAN OPTIONAL,
+      riscv64 BOOLEAN OPTIONAL,
+      riscv128 BOOLEAN OPTIONAL,
+      ...
+   }
+   PrivModes ::= SEQUENCE {
+      u BOOLEAN,
+      m BOOLEAN,
+      s BOOLEAN
+   }
+   PrivSatps ::= SEQUENCE {
+      sv32 BOOLEAN,
+      sv39 BOOLEAN,
+      sv48 BOOLEAN,
+      sv57 BOOLEAN,
+      sv64 BOOLEAN
+   }
+   Privileged ::= SEQUENCE {
+      modes PrivModes OPTIONAL,
+      satps PrivSatps OPTIONAL,
+      epmp BOOLEAN OPTIONAL,
+      ...
+   }
+   Clic ::= SEQUENCE {
+      mTimeRegisterAddress INTEGER OPTIONAL,
+      mTimeCompareRegisterAddress INTEGER OPTIONAL,
+      ...
+   }
+   FastInterruptModule ::= SEQUENCE {
+      index SEQUENCE OF Range OPTIONAL,
+      connectedHarts SEQUENCE OF Range OPTIONAL,
+      ...
+   }
+   TraceModule ::= SEQUENCE {
+      branchPredictorEntries INTEGER OPTIONAL,
+      jumpTargetCacheEntries INTEGER OPTIONAL,
+      contextBusWidth INTEGER OPTIONAL,
+      ...
+   }
+   PhysicalMemory ::= SEQUENCE {
+      address SEQUENCE OF Range,
+      cacheable BOOLEAN OPTIONAL,
+      lrScSupported BOOLEAN OPTIONAL,
+      ...
+   }
+   FastInt ::= SEQUENCE {
+      mModeTimeRegAddr INTEGER OPTIONAL,
+      mModeTimeCompRegAddr INTEGER OPTIONAL,
+      ...
+   }
+END
+
+Helper-Types
+DEFINITIONS
+   AUTOMATIC TAGS ::=
+BEGIN
+   EXPORTS FlexibleRange, FlexibleRange4, FlexibleRange8, FlexibleRange16,
+         Range;
 
    -- 2-bit integer
    Integer4 ::= INTEGER (0..3)
@@ -61,90 +162,137 @@ Configuration-Structure-Schema DEFINITIONS AUTOMATIC TAGS ::= BEGIN
       single SEQUENCE OF INTEGER OPTIONAL,
       range SEQUENCE OF Range OPTIONAL
    }
-   Hart ::= SEQUENCE {
-      hartid CHOICE { /* 4 choices use 2-bit as the index*/
-        hartId4  FlexibleRange4, /* For hart number [1..4] */
-        hartId8  FlexibleRange8, /* For hart number [1..8] */
-        hartId16 FlexibleRange8, /* For hart number [1..16] */
-        hartId   FlexibleRange   /* For hart number > 16 */
-      },
-      debug Debug OPTIONAL,
-      isa Isa OPTIONAL,
-      privileged Privileged OPTIONAL,
-      clic Clic OPTIONAL,
-      fastInt FastInt OPTIONAL,
-      ...
+END
+
+Debug-Extension
+DEFINITIONS
+   AUTOMATIC TAGS ::=
+BEGIN
+   EXPORTS Debug, DebugModule;
+   IMPORTS FlexibleRange FROM Helper-Types;
+
+   TriggerAction ::= BIT STRING {
+      breakpointException(0), debugMode(1),
+      -- TODO: Add trace actions
+      external0(2), external1(3)
    }
-   Tuple ::= SEQUENCE {
-      value INTEGER,
-      mask INTEGER
-   }
-   Triple ::= SEQUENCE {
-      low INTEGER,
-      high INTEGER,
-      mask INTEGER
-   }
-   PossibleValues ::= SEQUENCE {
-      tuple SEQUENCE OF Tuple OPTIONAL,
-      triple SEQUENCE OF Triple OPTIONAL,
-      ...
-   }
-   Configuration ::= SEQUENCE {
-      harts SEQUENCE OF Hart OPTIONAL,
-      debugModule SEQUENCE OF DebugModule OPTIONAL,
-      traceModule TraceModule OPTIONAL,
-      physicalMemory SEQUENCE OF PhysicalMemory OPTIONAL,
-      ...
-   }
-   DebugTriggerMcontrol ::= SEQUENCE {
-      maskmax INTEGER,
-      hit BOOLEAN,
+
+   TriggerMcontrol ::= SEQUENCE {
+      -- Describes both mcontrol and mcontrol6 type triggers, so include the
+      -- type.
+      type ENUMERATED {mcontrol, mcontrol6},
+      maskmax INTEGER (0..63),
+      vsSupported BOOLEAN,
+      vuSupported BOOLEAN,
+      hitSupported BOOLEAN,
+      selectSupported ENUMERATED {address, data, both},
+      timingSupported ENUMERATED {before, after, both},
       addressMatch BOOLEAN,
       dataMatch BOOLEAN,
-      timingBefore BOOLEAN,
-      timingAfter BOOLEAN,
-      sizeAny BOOLEAN,
-      sizeS8 BOOLEAN,
-      sizeS16 BOOLEAN,
-      sizeS32 BOOLEAN,
-      sizeS64 BOOLEAN,
-      sizeS80 BOOLEAN,
-      sizeS96 BOOLEAN,
-      sizeS112 BOOLEAN,
-      sizeS128 BOOLEAN,
-      actionMmode BOOLEAN,
-      actionDmode BOOLEAN,
-      chain BOOLEAN,
-      matchEqual BOOLEAN,
-      matchNapot BOOLEAN,
-      matchGreaterEqual BOOLEAN,
-      matchLess BOOLEAN,
-      matchLowMask BOOLEAN,
-      matchHighMask BOOLEAN,
-      matchNotEqual BOOLEAN,
-      matchNotNapot BOOLEAN,
-      matchNotLowMask BOOLEAN,
-      matchNotHighMask BOOLEAN,
-      m BOOLEAN,
-      s BOOLEAN,
-      u BOOLEAN,
-      execute BOOLEAN,
-      store BOOLEAN,
-      load BOOLEAN
-   }
-   DebugTrigger ::= SEQUENCE {
-      index FlexibleRange,
-      mcontrol SEQUENCE OF DebugTriggerMcontrol OPTIONAL,
+      sizeSupported BIT STRING {
+         any(0), b8(1), b16(2), b32(3), b64(4), b80(5), b96(6), b112(7), b128(8)
+      },
+      actionSupported TriggerAction,
+      chainSupported BOOLEAN,
+      matchesSupported BIT STRING {
+         equal(0), napot(1), greaterEqual(2), less(3), lowMask(4), highMask(5),
+         notEqual(6), notNapot(7), notLowMask(8), notHighMask(9)
+      },
+      mSupported BOOLEAN,
+      sSupported BOOLEAN,
+      uSupported BOOLEAN,
+      executeSupported BOOLEAN,
+      storeSupported BOOLEAN,
+      loadSupported BOOLEAN,
       ...
    }
+
+   TriggerIcount ::= SEQUENCE {
+      vsSupported BOOLEAN,
+      vuSupported BOOLEAN,
+      hitSupported BOOLEAN,
+      countMax INTEGER (1..16383),
+      mSupported BOOLEAN,
+      sSupported BOOLEAN,
+      uSupported BOOLEAN,
+      actionSupported TriggerAction,
+      ...
+   }
+
+   TriggerItrigger ::= SEQUENCE {
+      hitSupported BOOLEAN,
+      vsSupported BOOLEAN,
+      vuSupported BOOLEAN,
+      mSupported BOOLEAN,
+      sSupported BOOLEAN,
+      uSupported BOOLEAN,
+      actionSupported TriggerAction,
+      -- Intentionally not describing possible tdata2 values. TODO: Should we?
+      -- Certainly it's an implementation decision which interrupts we can
+      -- trigger on, but it's fairly easy to discover which values are valid.
+      -- Where exactly do we draw the line on how much detail to describe?
+      ...
+   }
+
+   TriggerEtrigger ::= SEQUENCE {
+      hitSupported BOOLEAN,
+      vsSupported BOOLEAN,
+      vuSupported BOOLEAN,
+      nmiSupported BOOLEAN,
+      mSupported BOOLEAN,
+      sSupported BOOLEAN,
+      uSupported BOOLEAN,
+      actionSupported TriggerAction,
+      ...
+   }
+
+   TriggerTmexttrigger ::= SEQUENCE {
+      hitSupported BOOLEAN,
+      intctlSupported BOOLEAN,
+      selectSupported BIT STRING, -- TODO: Constrain length
+      actionSupported TriggerAction,
+      ...
+   }
+
+   DebugTrigger ::= SEQUENCE {
+      index FlexibleRange,
+      -- TODO: Do we need to replicate TriggerAction in every instance of every
+      -- trigger? That seems wasteful in size, and really what implementation
+      -- would have different actions for different triggers?
+      mcontrol SEQUENCE OF TriggerMcontrol OPTIONAL,
+      icount SEQUENCE OF TriggerIcount OPTIONAL,
+      itrigger SEQUENCE OF TriggerItrigger OPTIONAL,
+      etrigger SEQUENCE OF TriggerEtrigger OPTIONAL,
+      ...
+   }
+
+   ContextInfo ::= SEQUENCE {
+      tcontrol SEQUENCE {
+         hcxeSupported BOOLEAN,
+         scxeSupported BOOLEAN,
+         mpteSupported BOOLEAN,
+         mteSupported BOOLEAN,
+         ...
+      },
+      hcontextSupported BOOLEAN,
+      scontextSupported BOOLEAN,
+      mcontextSupported BOOLEAN,
+      ...
+   }
+
    AccessRegisterCommand ::= SEQUENCE {
-      aarsize32 BOOLEAN,
-      aarsize64 BOOLEAN,
-      aarsize128 BOOLEAN,
+      aarsize BIT STRING {s32 (0), s64(1), s128(2)},
       aarpostincrementSupported BOOLEAN,
       postexecSupported BOOLEAN,
-      regno FlexibleRange
+      regno FlexibleRange,
+      ...
    }
+   
+   QuickAccessCommand ::= SEQUENCE {
+      supported BOOLEAN,
+      ...
+   }
+
    AccessMemoryCommand ::= SEQUENCE {
       aamvirtual0 BOOLEAN,
       aamvirtual1 BOOLEAN,
@@ -155,74 +303,79 @@ Configuration-Structure-Schema DEFINITIONS AUTOMATIC TAGS ::= BEGIN
       aamsize128 BOOLEAN,
       aampostincrementSupported BOOLEAN,
       writeSupported BOOLEAN,
-      readSupported BOOLEAN
+      readSupported BOOLEAN,
+      ...
    }
+
    AbstractCommand ::= SEQUENCE {
+      -- Enumerate every supported abstract command. It is not required to list
+      -- AccessRegisterCommand for the GPRs since that functionality is required
+      -- by the spec.
       accessRegister SEQUENCE OF AccessRegisterCommand OPTIONAL,
-      quickAccess SEQUENCE OF BOOLEAN OPTIONAL,
+      quickAccess SEQUENCE OF QuickAccessCommand OPTIONAL,
       accessMemory SEQUENCE OF AccessMemoryCommand OPTIONAL,
       ...
    }
+
+   DmControl ::= SEQUENCE {
+      hartresetSupported BOOLEAN,
+      -- If hartselLen is 0, hasel is tied to 0.
+      hartselLen INTEGER (0..20),
+      keepaliveSupported BOOLEAN,
+      resethaltreqSuported BOOLEAN,
+      ...
+   }
+
+   HartInfo ::= SEQUENCE {
+      -- TODO: These are simple read-only fields in the hardware. Do they need
+      -- to be here?
+      nscratch INTEGER (0..15),
+      datasize INTEGER (0..15),
+      -- The choice picked here indicates the value of dataaccess.
+      dataaddr CHOICE {
+         csr INTEGER (0..4095),
+         address INTEGER (-2048 .. 2047)
+      },
+      ...
+   }
+
+   AbstractCs ::= SEQUENCE {
+      relaxedprivSupported BOOLEAN,
+      ...
+   }
+
+   AbstractAuto ::= SEQUENCE {
+      autoexecprogbuf BIT STRING, -- TODO: Constrain length to 16 bits
+      autoexecdata BIT STRING, -- TODO: Constrain length to 12 bits
+      ...
+   }
+
+   SystemBus ::= SEQUENCE {
+      accessSizes BIT STRING {s8 (0), s16 (1), s32 (2), s64 (3), s128 (4)},
+      ...
+   }
+
    DebugModule ::= SEQUENCE {
+      -- DMI address of this debug module. Will almost always be 0, in which
+      -- case it can be omitted.
+      dmiAddress INTEGER DEFAULT 0,
+
+      mcontrol DmControl,
+      hartinfo HartInfo,
+      abstractcs AbstractCs,
+
+      haltGroupCount INTEGER (1..31) OPTIONAL,
+      resumeGroupCount INTEGER (1..31) OPTIONAL,
+
       index INTEGER OPTIONAL,
-      abstract AbstractCommand OPTIONAL,
+      abstract AbstractCommand,
       connectedHarts FlexibleRange OPTIONAL,
       ...
    }
+
    Debug ::= SEQUENCE {
+      contextInfo ContextInfo OPTIONAL,
       trigger SEQUENCE OF DebugTrigger OPTIONAL,
       ...
    }
-   Isa ::= SEQUENCE {
-      riscv32 BOOLEAN OPTIONAL,
-      riscv64 BOOLEAN OPTIONAL,
-      riscv128 BOOLEAN OPTIONAL,
-      ...
-   }
-   PrivModes ::= SEQUENCE {
-      u BOOLEAN,
-      m BOOLEAN,
-      s BOOLEAN
-   }
-   PrivSatps ::= SEQUENCE {
-      sv32 BOOLEAN,
-      sv39 BOOLEAN,
-      sv48 BOOLEAN,
-      sv57 BOOLEAN,
-      sv64 BOOLEAN
-   }
-   Privileged ::= SEQUENCE {
-      modes PrivModes OPTIONAL,
-      satps PrivSatps OPTIONAL,
-      epmp BOOLEAN OPTIONAL,
-      ...
-   }
-   Clic ::= SEQUENCE {
-      mTimeRegisterAddress INTEGER OPTIONAL,
-      mTimeCompareRegisterAddress INTEGER OPTIONAL,
-      ...
-   }
-   FastInterruptModule ::= SEQUENCE {
-      index SEQUENCE OF Range OPTIONAL,
-      connectedHarts SEQUENCE OF Range OPTIONAL,
-      ...
-   }
-   TraceModule ::= SEQUENCE {
-      branchPredictorEntries INTEGER OPTIONAL,
-      jumpTargetCacheEntries INTEGER OPTIONAL,
-      contextBusWidth INTEGER OPTIONAL,
-      ...
-   }
-   PhysicalMemory ::= SEQUENCE {
-      address SEQUENCE OF Range,
-      cacheable BOOLEAN OPTIONAL,
-      lrScSupported BOOLEAN OPTIONAL,
-      ...
-   }
-   FastInt ::= SEQUENCE {
-      mModeTimeRegAddr INTEGER OPTIONAL,
-      mModeTimeCompRegAddr INTEGER OPTIONAL,
-      ...
-   }
 END
-

--- a/schema.asn
+++ b/schema.asn
@@ -377,6 +377,50 @@ BEGIN
       ...
    }
 
+   HartInfo ::= SEQUENCE {
+      hartid FlexibleRange,
+      nscratch INTEGER (0..15) DEFAULT 0,
+      dataaccess CHOICE {
+         none NULL,
+         csr SEQUENCE {
+            count INTEGER (1..15),
+            address INTEGER(0..4095)
+         },
+         memory SEQUENCE {
+            wordCount INTEGER (1..15),
+            address INTEGER (-2048..2047)
+         }
+      },
+      ...
+   }
+
+   -- Information about a debug module that is trivial to read. This section is
+   -- helpful for descriptions of the hardware when the hardware itself is not
+   -- accessible.
+   DebugModuleComplete ::= SEQUENCE {
+      stickyunavail BOOLEAN DEFAULT FALSE,
+      impebreak BOOLEAN DEFAULT FALSE,
+      hasresethaltreq BOOLEAN DEFAULT FALSE,
+      confstrptrvalid BOOLEAN DEFAULT FALSE,
+      version ENUMERATED {v0-11, v0-13, v1-0, ...},
+
+      hartInfo SEQUENCE OF HartInfo OPTIONAL,
+
+      progbufsize INTEGER (0..16) DEFAULT 0,
+      datacount INTEGER (1..12) DEFAULT 1,
+
+      -- TODO: Figure out what to do about confstrptr. Should it be included?
+      sbversion INTEGER (0..7),
+      sbasize INTEGER (0..127),
+      sbaccess128Supported BOOLEAN DEFAULT FALSE,
+      sbaccess64Supported BOOLEAN DEFAULT FALSE,
+      sbaccess32Supported BOOLEAN DEFAULT FALSE,
+      sbaccess16Supported BOOLEAN DEFAULT FALSE,
+      sbaccess8Supported BOOLEAN DEFAULT FALSE,
+      ...
+   }
+
+   -- Describes a debug module that sits outside a hart.
    DebugModule ::= SEQUENCE {
       -- Where this DM is in the chain of DMs. Will almost always be 0.
       index INTEGER DEFAULT 0,
@@ -389,12 +433,27 @@ BEGIN
 
       abstract Abstract,
       runControl RunControl,
+      complete DebugModuleComplete OPTIONAL,
+
+      -- TODO: Should we put vendorExtension SEQUENCE OF OCTET STRING OPTIONAL here?
       ...
    }
 
+   DebugComplete ::= SEQUENCE {
+      debugver INTEGER (1..15),
+      ...
+   }
+
+   -- Describes the debug features built into a specific hart.
    Debug ::= SEQUENCE {
+      stepieSupported BOOLEAN DEFAULT FALSE,
+      stopcountSupported BOOLEAN DEFAULT FALSE,
+      stoptimeSupported BOOLEAN DEFAULT FALSE,
+      mprvenSupported ENUMERATED {on, off, both} DEFAULT off,
+
       contextInfo ContextInfo OPTIONAL,
       trigger SEQUENCE OF DebugTrigger OPTIONAL,
+      complete DebugComplete OPTIONAL,
       ...
    }
 END


### PR DESCRIPTION
Refactored the schema into multiple DEFINITIONS so that each extension can provide its own one. That avoids name space conflicts, and makes it clear who "owns" what part of the document.

Some small choices I made:
1. Using fooSupported to indicate whether foo is supported or not, while I'm just using `bar` if there is a bit called `bar` that always reads as one.
2. Allow full description of every implementation decision that software might care about. However, the stuff that can be trivially read from the hardware is put into the optional Complete section so that small descriptions don't have to include it.

Modified rvcs.py so that `test` can now deal with default values. (This was a problem before because it would constitute a value not specified in the input but showing up in the output.)

examples/debug_module.jer is 18B in UPER
examples/example.jer is 90B in UPER