### PR TITLE
Initial support for scalar crypto v1.0.0-rc3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@
 ## Test changes
 
 `make test` or `./asn1tools/rvcs.py test examples/*.jer`
+
+Several python libraries are required to run the tests.
+See the `requirements.txt` file, or run `pip3 install -r requirements.txt`
+
+to install them all automatically.

--- a/examples/example.jer
+++ b/examples/example.jer
@@ -186,6 +186,14 @@
             "fastInt": {
                 "mModeTimeRegAddr": 4660,
                 "mModeTimeCompRegAddr": 4660
+            },
+            "zk" : {
+                "zbkbSupported": true,
+                "zbkxSupported": true,
+                "zkndSupported": true,
+                "zkneSupported": true,
+                "zknhSupported": true,
+                "zkrSupported": true
             }
         }
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+asn1tools
+deepdiff

--- a/schema/configuration-structure.asn
+++ b/schema/configuration-structure.asn
@@ -7,7 +7,9 @@ BEGIN
       Tuple, Triple, PossibleValue, PhysicalAddress FROM Helper-Types
       Isa, PrivModes, PrivSatps, Privileged FROM Hart-Extension
       VirtMem FROM Virtual-Memory-Extension
-      Zjpm FROM Zjpm-Extension;
+      Zjpm FROM Zjpm-Extension
+      Zk   FROM Zk-Extensions
+      ;
 
    CustomOctetString ::= SEQUENCE {
       -- Ideally we'd build something based on information object classes.
@@ -49,6 +51,7 @@ BEGIN
       custom SEQUENCE OF Custom OPTIONAL,
       virtmem VirtMem OPTIONAL,
       zjpm Zjpm OPTIONAL,
+      zk    Zk  OPTIONAL,
       ...
    }
 

--- a/schema/zk-extensions.asn
+++ b/schema/zk-extensions.asn
@@ -1,0 +1,35 @@
+Zk-Extensions
+DEFINITIONS
+    AUTOMATIC TAGS ::=
+BEGIN
+    EXPORTS Zk;
+
+    -- Zk refers to the scalar cryptography extensions
+
+    Zk ::= SEQUENCE {
+
+        -- Instruction Extensions Overlapping with Bitmanip
+        zbkbSupported   BOOLEAN DEFAULT FALSE,
+        zbkcSupported   BOOLEAN DEFAULT FALSE,
+        zbkxSupported   BOOLEAN DEFAULT FALSE,
+
+        -- Zkn (NIST) extensions
+        zkndSupported   BOOLEAN DEFAULT FALSE,
+        zkneSupported   BOOLEAN DEFAULT FALSE,
+        zknhSupported   BOOLEAN DEFAULT FALSE,
+
+        -- Zks (ShangMi) extensions
+        zksedSupported  BOOLEAN DEFAULT FALSE,
+        zkshSupported   BOOLEAN DEFAULT FALSE,
+
+        -- Constant Time execution
+        zktSupported    BOOLEAN DEFAULT FALSE,
+
+        -- Entropy Source Extension
+        zkrSupported    BOOLEAN DEFAULT FALSE,
+
+        ...
+
+    }
+END
+


### PR DESCRIPTION
Hi there

This PR adds support to the configuration structure for the scalar cryptography extensions v1.0.0-rc3. The following extensions are added:
- `Zbkb` - Basic bitmanip instructions for cryptography
- `Zbkc` - Carryless multiply
- `Zbkx` - `xperm*` instructions
- `Zknd` - NIST AES decrypt instructions
- `Zkne` - NIST AES encrypt instructions
- `Zknh` - NIST SHA2 hash instructions
- `Zksed` - SM4 encrypt/decrypt instructions
- `Zksh` - SM3 hash function instructions
- `Zkt` - Constant time mode indicator
- `Zkr` - Entropy source.

Each extension is a single bit in the config structure. I've tried structure them one file per extension. Looking forward to a world where RISC-V has _many_ extensions, this seemed the most sensible, rather than hiding multiple extensions in fewer files.

One open question: The `Zkr` extension - access to the entropy source is always possible in M mode, and optionally enabled in S/U mode based on corresponding bits in the `mseccfg` register. These bits can be hardwired or read/writeable. I have not encoded whether these bits are read/write in the config structure. My rationale was that SW only needs to know if the bits exist (because `Zkr` is indicated by the config structure), and can go and test them itself. So encoding them in the config structure would be redundant information. I hope this is the right call.

Please let me know if there's anything which would improve this PR, I'm happy iterating on it.

Thanks,
Ben