### PR TITLE
Add a tiny header for future proofing.

### DIFF
--- a/asn1tools/rvcs.py
+++ b/asn1tools/rvcs.py
@@ -11,6 +11,7 @@ import json
 import os.path
 import sys
 from pprint import pprint
+from pyparsing import originalTextFor
 
 import yaml
 
@@ -26,7 +27,7 @@ def decode(schema_list, data, asn1_format):
         return yaml.safe_load(stream)
     if asn1_format in ASN1TOOLS_FORMATS:
         asn1 = asn1tools.compile_files(schema_list, asn1_format)
-        return asn1.decode('Configuration', data)
+        return asn1.decode('Top', data)
     raise ValueError("Unknown format: %r" % asn1_format)
 
 def load(schema_list, path):
@@ -41,7 +42,7 @@ def encode(schema_list, tree, asn1_format):
         return yaml.safe_dump(tree, indent=2).encode()
     if asn1_format in ASN1TOOLS_FORMATS:
         asn1 = asn1tools.compile_files(schema_list, asn1_format)
-        return asn1.encode('Configuration', tree)
+        return asn1.encode('Top', tree)
     raise ValueError("Unknown format: %r" % asn1_format)
 
 def save(schema_list, path, tree):

--- a/asn1tools/rvcs.py
+++ b/asn1tools/rvcs.py
@@ -11,7 +11,6 @@ import json
 import os.path
 import sys
 from pprint import pprint
-from pyparsing import originalTextFor
 
 import yaml
 

--- a/examples/debug_module.jer
+++ b/examples/debug_module.jer
@@ -1,32 +1,34 @@
 {
-    "debugModule": [
-        {
-            "accessRegisterCommand": [
-                {
-                    "aarsize64Supported": true,
-                    "aarsize128Supported": true,
-                    "aarpostincrementSupported": false,
-                    "postexecSupported": true,
-                    "regno": {
+    "configuration": {
+        "debugModule": [
+            {
+                "accessRegisterCommand": [
+                    {
+                        "aarsize64Supported": true,
+                        "aarsize128Supported": true,
+                        "aarpostincrementSupported": false,
+                        "postexecSupported": true,
+                        "regno": {
+                            "range" : [
+                                {
+                                    "start": 4096,
+                                    "length": 31
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "secondary": {
+                    "connectedHarts": {
                         "range" : [
                             {
-                                "start": 4096,
-                                "length": 31
+                                    "start": 0,
+                                    "length": 4
                             }
                         ]
                     }
                 }
-            ],
-            "secondary": {
-                "connectedHarts": {
-                    "range" : [
-                        {
-                                "start": 0,
-                                "length": 4
-                        }
-                    ]
-                }
             }
-        }
-    ]
+        ]
+    }
 }

--- a/examples/example.jer
+++ b/examples/example.jer
@@ -1,226 +1,228 @@
 {
-    "harts": [
-        {
-            "hartid": {
-                "hartId4": {
-                    "single": [
-                        0
-                    ]
-                }
-            },
-            "debug": {
-                "trigger": [
-                    {
-                        "index" : {
-                            "range": [
+    "configuration": {
+        "harts": [
+            {
+                "hartid": {
+                    "hartId4": {
+                        "single": [
+                            0
+                        ]
+                    }
+                },
+                "debug": {
+                    "trigger": [
+                        {
+                            "index" : {
+                                "range": [
+                                    {
+                                        "start": 0,
+                                        "length": 3
+                                        }
+                                ]
+                            },
+                            "actionSupported": {
+                                    "breakpointExceptionSupported": true,
+                                    "debugModeSupported": true
+                            },
+                            "mcontrol": [
                                 {
-                                    "start": 0,
-                                    "length": 3
-                                    }
+                                    "maskmax": 4,
+                                    "selectSupported": "data",
+                                    "timingSupported": "before",
+                                    "sizeAny": true,
+                                    "matchEqual": true,
+                                    "matchNapot": true,
+                                    "matchGreaterEqual": true,
+                                    "matchLess": true,
+                                    "executeSupported": true,
+                                    "storeSupported": true,
+                                    "loadSupported": true
+                                }
                             ]
                         },
-                        "actionSupported": {
-                                "breakpointExceptionSupported": true,
-                                "debugModeSupported": true
-                        },
-                        "mcontrol": [
+                        {
+                            "index": {
+                                "single": [ 4 ]
+                            },
+                            "actionSupported": {
+                                    "breakpointExceptionSupported": true,
+                                    "debugModeSupported": true
+                            },
+                            "mcontrol": [
+                                {
+                                    "maskmax": 4,
+                                    "selectSupported": "address",
+                                    "sizeAny": true,
+                                    "dataMatch": true,
+                                    "timingSupported": "before",
+                                    "matchEqual": true,
+                                    "matchNapot": true,
+                                    "matchGreaterEqual": true,
+                                    "matchLess": true,
+                                    "executeSupported": true,
+                                    "storeSupported": true,
+                                    "loadSupported": true
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "hartid": {
+                    "hartId8": {
+                        "range": [
                             {
-                                "maskmax": 4,
-                                "selectSupported": "data",
-                                "timingSupported": "before",
-                                "sizeAny": true,
-                                "matchEqual": true,
-                                "matchNapot": true,
-                                "matchGreaterEqual": true,
-                                "matchLess": true,
-                                "executeSupported": true,
-                                "storeSupported": true,
-                                "loadSupported": true
+                                "start": 1,
+                                "length": 4
                             }
                         ]
+                    }
+                },
+                "debug": {
+                    "trigger": [
+                        {
+                            "index": {
+                                "single": [
+                                    4
+                                ]
+                            },
+                            "actionSupported": {
+                                    "breakpointExceptionSupported": true,
+                                    "debugModeSupported": true
+                            },
+                            "mcontrol": [
+                                {
+                                    "maskmax": 4,
+                                    "sizeAny": true,
+                                    "selectSupported": "data",
+                                    "timingSupported": "before",
+                                    "matchEqual": true,
+                                    "matchNapot": true,
+                                    "matchGreaterEqual": true,
+                                    "matchLess": true,
+                                    "executeSupported": true,
+                                    "storeSupported": true,
+                                    "loadSupported": true
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "hartid": {
+                    "hartId8": {
+                        "single": [
+                            0,
+                            2,
+                            4
+                        ]
+                    }
+                },
+                "isa": {
+                    "riscv32": true,
+                    "riscv64": true
+                },
+                "privileged": {
+                    "modes": {
+                        "m": true,
+                        "s": true,
+                        "u": true
                     },
-                    {
-                        "index": {
-                            "single": [ 4 ]
-                        },
-                        "actionSupported": {
-                                "breakpointExceptionSupported": true,
-                                "debugModeSupported": true
-                        },
-                        "mcontrol": [
+                    "epmp": true,
+                    "satps": {
+                        "sv32": false,
+                        "sv39": true,
+                        "sv48": true,
+                        "sv57": true,
+                        "sv64": true
+                    }
+                },
+                "virtmem": {
+                    "svnapot": true,
+                    "svpbmt": true,
+                    "svinval": true
+                }
+            },
+            {
+                "hartid": {
+                    "hartId4": {
+                        "single": [
+                            1,
+                            3
+                        ]
+                    }
+                },
+                "isa": {
+                    "riscv64": true
+                },
+                "privileged": {
+                    "modes": {
+                        "u": false,
+                        "m": true,
+                        "s": false
+                    },
+                    "epmp": true,
+                    "satps": {
+                        "sv32": false,
+                        "sv39": false,
+                        "sv48": false,
+                        "sv57": false,
+                        "sv64": false
+                    }
+                }
+            },
+            {
+                "hartid": {
+                    "hartId8": {
+                        "range": [
                             {
-                                "maskmax": 4,
-                                "selectSupported": "address",
-                                "sizeAny": true,
-                                "dataMatch": true,
-                                "timingSupported": "before",
-                                "matchEqual": true,
-                                "matchNapot": true,
-                                "matchGreaterEqual": true,
-                                "matchLess": true,
-                                "executeSupported": true,
-                                "storeSupported": true,
-                                "loadSupported": true
+                                "start": 1,
+                                "length": 4
                             }
                         ]
                     }
-                ]
-            }
-        },
-        {
-            "hartid": {
-                "hartId8": {
-                    "range": [
-                        {
-                            "start": 1,
-                            "length": 4
-                        }
-                    ]
+                },
+                "fastInt": {
+                    "mModeTimeRegAddr": 4660,
+                    "mModeTimeCompRegAddr": 4660
                 }
-            },
-            "debug": {
-                "trigger": [
+            }
+        ],
+        "debugModule": [
+            {
+                "accessRegisterCommand": [
                     {
-                        "index": {
-                            "single": [
-                                4
+                        "aarsize64Supported": true,
+                        "aarsize128Supported": true,
+                        "postexecSupported": true,
+                        "regno": {
+                            "range" : [
+                                {
+                                    "start": 4096,
+                                    "length": 31
+                                }
                             ]
-                        },
-                        "actionSupported": {
-                                "breakpointExceptionSupported": true,
-                                "debugModeSupported": true
-                        },
-                        "mcontrol": [
-                            {
-                                "maskmax": 4,
-                                "sizeAny": true,
-                                "selectSupported": "data",
-                                "timingSupported": "before",
-                                "matchEqual": true,
-                                "matchNapot": true,
-                                "matchGreaterEqual": true,
-                                "matchLess": true,
-                                "executeSupported": true,
-                                "storeSupported": true,
-                                "loadSupported": true
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        {
-            "hartid": {
-                "hartId8": {
-                    "single": [
-                        0,
-                        2,
-                        4
-                    ]
-                }
-            },
-            "isa": {
-                "riscv32": true,
-                "riscv64": true
-            },
-            "privileged": {
-                "modes": {
-                    "m": true,
-                    "s": true,
-                    "u": true
-                },
-                "epmp": true,
-                "satps": {
-                    "sv32": false,
-                    "sv39": true,
-                    "sv48": true,
-                    "sv57": true,
-                    "sv64": true
-                }
-            },
-            "virtmem": {
-                "svnapot": true,
-                "svpbmt": true,
-                "svinval": true
-            }
-        },
-        {
-            "hartid": {
-                "hartId4": {
-                    "single": [
-                        1,
-                        3
-                    ]
-                }
-            },
-            "isa": {
-                "riscv64": true
-            },
-            "privileged": {
-                "modes": {
-                    "u": false,
-                    "m": true,
-                    "s": false
-                },
-                "epmp": true,
-                "satps": {
-                    "sv32": false,
-                    "sv39": false,
-                    "sv48": false,
-                    "sv57": false,
-                    "sv64": false
-                }
-            }
-        },
-        {
-            "hartid": {
-                "hartId8": {
-                    "range": [
-                        {
-                            "start": 1,
-                            "length": 4
                         }
-                    ]
-                }
-            },
-            "fastInt": {
-                "mModeTimeRegAddr": 4660,
-                "mModeTimeCompRegAddr": 4660
-            }
-        }
-    ],
-    "debugModule": [
-        {
-            "accessRegisterCommand": [
-                {
-                    "aarsize64Supported": true,
-                    "aarsize128Supported": true,
-                    "postexecSupported": true,
-                    "regno": {
+                    }
+                ],
+                "secondary": {
+                    "connectedHarts": {
                         "range" : [
                             {
-                                "start": 4096,
-                                "length": 31
+                                    "start": 0,
+                                    "length": 4
                             }
                         ]
                     }
                 }
-            ],
-            "secondary": {
-                "connectedHarts": {
-                    "range" : [
-                        {
-                                "start": 0,
-                                "length": 4
-                        }
-                    ]
-                }
             }
+        ],
+        "traceModule": {
+            "branchPredictorEntries": 0,
+            "jumpTargetCacheEntries": 0,
+            "contextBusWidth": 32
         }
-    ],
-    "traceModule": {
-        "branchPredictorEntries": 0,
-        "jumpTargetCacheEntries": 0,
-        "contextBusWidth": 32
     }
 }

--- a/schema/configuration-structure.asn
+++ b/schema/configuration-structure.asn
@@ -61,7 +61,7 @@ BEGIN
       -- extended in a backwards compatible way. With the default value, this
       -- encodes as a single bit. Decoders must confirm that the version they
       -- get back here matches what they expect.
-      version INTEGER DEFAULT 1,
+      version INTEGER (1..32) DEFAULT 1,
 
       -- If we bump the version number, we will probably no longer include the
       -- Configuration. That means the optional bit will be set to 0, and a UPER

--- a/schema/configuration-structure.asn
+++ b/schema/configuration-structure.asn
@@ -52,24 +52,25 @@ BEGIN
       ...
    }
 
-   Top ::= SEQUENCE {
+   Top ::= CHOICE {
       -- This wrapper is here in case in the future we want to change to a
       -- different encoding, or in some other way completely overhaul what we're
       -- doing.
 
-      -- Version 1 means we're using this UPER schema, which may have been
-      -- extended in a backwards compatible way. With the default value, this
-      -- encodes as a single bit. Decoders must confirm that the version they
-      -- get back here matches what they expect.
-      version INTEGER (1..32) DEFAULT 1,
+      -- In the current schema we always use Configuration. This choice ends up
+      -- encoded as 2 bits (extended:1'h0 index:1'h0) followed by the
+      -- Configuration itself.
+      configuration Configuration,
 
-      -- If we bump the version number, we will probably no longer include the
-      -- Configuration. That means the optional bit will be set to 0, and a UPER
-      -- decoder built with this version of the schema will end parsing at this
-      -- point.  That means that after these initial 2 bits we can safely add
-      -- more stuff, either using UPER again or even raw data in any other
-      -- format.
-      configuration Configuration OPTIONAL
+      -- If we want to change to a different encoding (not ASN.1 UPER) then we
+      -- can set this value. The choice ends up encoded as 8 bits (extended:1'h0
+      -- index:1'h1 <alternateEncoding>). This is simply translates into a
+      -- constant byte prefix for potential future alternative encodings.
+      alternateEncoding INTEGER (0..63),
+      ...
+      -- If we want to move to a different kind of Configuration object in the
+      -- future, we can put it here, using ASN.1's native extension mechanism.
+      -- Encoded as (extended:1'h1 index:5'h0 length:... contents:...)
    }
 
    Configuration ::= SEQUENCE {

--- a/schema/configuration-structure.asn
+++ b/schema/configuration-structure.asn
@@ -52,6 +52,26 @@ BEGIN
       ...
    }
 
+   Top ::= SEQUENCE {
+      -- This wrapper is here in case in the future we want to change to a
+      -- different encoding, or in some other way completely overhaul what we're
+      -- doing.
+
+      -- Version 1 means we're using this UPER schema, which may have been
+      -- extended in a backwards compatible way. With the default value, this
+      -- encodes as a single bit. Decoders must confirm that the version they
+      -- get back here matches what they expect.
+      version INTEGER DEFAULT 1,
+
+      -- If we bump the version number, we will probably no longer include the
+      -- Configuration. That means the optional bit will be set to 0, and a UPER
+      -- decoder built with this version of the schema will end parsing at this
+      -- point.  That means that after these initial 2 bits we can safely add
+      -- more stuff, either using UPER again or even raw data in any other
+      -- format.
+      configuration Configuration OPTIONAL
+   }
+
    Configuration ::= SEQUENCE {
       harts SEQUENCE OF Hart OPTIONAL,
       debugModule SEQUENCE OF DebugModule OPTIONAL,


### PR DESCRIPTION
ASN.1 lets us add fields anywhere we marked things extensible, but what
if in some future we want to switch to a different ASN.1 encoding, or
even off of ASN.1 altogether?

This change adds a 2-bit header that will expand to be minimal overhead
if we want to switch to something else in the future (9 bits, I think).
It's unlikely that we will go that route, but this prepares us just in
case.

Also see mailing list subject:"configuration structure header"