### PR TITLE
Use SEQUENCE OF CHOICE instead of OPTIONAL.

### DIFF
--- a/examples/example.jer
+++ b/examples/example.jer
@@ -9,64 +9,70 @@
                         ]
                     }
                 },
-                "debug": {
-                    "trigger": [
-                        {
-                            "index" : {
-                                "range": [
-                                    {
-                                        "start": 0,
-                                        "length": 3
+                "extensions": [
+                    {
+                        "debug": {
+                            "trigger": [
+                                {
+                                    "index": {
+                                        "range": [
+                                            {
+                                                "start": 0,
+                                                "length": 3
+                                            }
+                                        ]
+                                    },
+                                    "actionSupported": {
+                                        "breakpointExceptionSupported": true,
+                                        "debugModeSupported": true
+                                    },
+                                    "mcontrol": [
+                                        {
+                                            "maskmax": 4,
+                                            "selectSupported": "data",
+                                            "timingSupported": "before",
+                                            "sizeAny": true,
+                                            "matchEqual": true,
+                                            "matchNapot": true,
+                                            "matchGreaterEqual": true,
+                                            "matchLess": true,
+                                            "executeSupported": true,
+                                            "storeSupported": true,
+                                            "loadSupported": true
                                         }
-                                ]
-                            },
-                            "actionSupported": {
-                                    "breakpointExceptionSupported": true,
-                                    "debugModeSupported": true
-                            },
-                            "mcontrol": [
+                                    ]
+                                },
                                 {
-                                    "maskmax": 4,
-                                    "selectSupported": "data",
-                                    "timingSupported": "before",
-                                    "sizeAny": true,
-                                    "matchEqual": true,
-                                    "matchNapot": true,
-                                    "matchGreaterEqual": true,
-                                    "matchLess": true,
-                                    "executeSupported": true,
-                                    "storeSupported": true,
-                                    "loadSupported": true
-                                }
-                            ]
-                        },
-                        {
-                            "index": {
-                                "single": [ 4 ]
-                            },
-                            "actionSupported": {
-                                    "breakpointExceptionSupported": true,
-                                    "debugModeSupported": true
-                            },
-                            "mcontrol": [
-                                {
-                                    "maskmax": 4,
-                                    "selectSupported": "address",
-                                    "sizeAny": true,
-                                    "dataMatch": true,
-                                    "timingSupported": "before",
-                                    "matchEqual": true,
-                                    "matchNapot": true,
-                                    "matchGreaterEqual": true,
-                                    "matchLess": true,
-                                    "executeSupported": true,
-                                    "storeSupported": true,
-                                    "loadSupported": true
+                                    "index": {
+                                        "single": [
+                                            4
+                                        ]
+                                    },
+                                    "actionSupported": {
+                                        "breakpointExceptionSupported": true,
+                                        "debugModeSupported": true
+                                    },
+                                    "mcontrol": [
+                                        {
+                                            "maskmax": 4,
+                                            "selectSupported": "address",
+                                            "sizeAny": true,
+                                            "dataMatch": true,
+                                            "timingSupported": "before",
+                                            "matchEqual": true,
+                                            "matchNapot": true,
+                                            "matchGreaterEqual": true,
+                                            "matchLess": true,
+                                            "executeSupported": true,
+                                            "storeSupported": true,
+                                            "loadSupported": true
+                                        }
+                                    ]
                                 }
                             ]
                         }
-                    ]
-                }
+                    }
+                ]
             },
             {
                 "hartid": {
@@ -79,36 +85,40 @@
                         ]
                     }
                 },
-                "debug": {
-                    "trigger": [
-                        {
-                            "index": {
-                                "single": [
-                                    4
-                                ]
-                            },
-                            "actionSupported": {
-                                    "breakpointExceptionSupported": true,
-                                    "debugModeSupported": true
-                            },
-                            "mcontrol": [
+                "extensions": [
+                    {
+                        "debug": {
+                            "trigger": [
                                 {
-                                    "maskmax": 4,
-                                    "sizeAny": true,
-                                    "selectSupported": "data",
-                                    "timingSupported": "before",
-                                    "matchEqual": true,
-                                    "matchNapot": true,
-                                    "matchGreaterEqual": true,
-                                    "matchLess": true,
-                                    "executeSupported": true,
-                                    "storeSupported": true,
-                                    "loadSupported": true
+                                    "index": {
+                                        "single": [
+                                            4
+                                        ]
+                                    },
+                                    "actionSupported": {
+                                        "breakpointExceptionSupported": true,
+                                        "debugModeSupported": true
+                                    },
+                                    "mcontrol": [
+                                        {
+                                            "maskmax": 4,
+                                            "sizeAny": true,
+                                            "selectSupported": "data",
+                                            "timingSupported": "before",
+                                            "matchEqual": true,
+                                            "matchNapot": true,
+                                            "matchGreaterEqual": true,
+                                            "matchLess": true,
+                                            "executeSupported": true,
+                                            "storeSupported": true,
+                                            "loadSupported": true
+                                        }
+                                    ]
                                 }
                             ]
                         }
-                    ]
-                }
+                    }
+                ]
             },
             {
                 "hartid": {
@@ -124,26 +134,32 @@
                     "riscv32": true,
                     "riscv64": true
                 },
-                "privileged": {
-                    "modes": {
-                        "m": true,
-                        "s": true,
-                        "u": true
+                "extensions": [
+                    {
+                        "privileged": {
+                            "modes": {
+                                "m": true,
+                                "s": true,
+                                "u": true
+                            },
+                            "epmp": true,
+                            "satps": {
+                                "sv32": false,
+                                "sv39": true,
+                                "sv48": true,
+                                "sv57": true,
+                                "sv64": true
+                            }
+                        }
                     },
-                    "epmp": true,
-                    "satps": {
-                        "sv32": false,
-                        "sv39": true,
-                        "sv48": true,
-                        "sv57": true,
-                        "sv64": true
+                    {
+                        "virtmem": {
+                            "svnapot": true,
+                            "svpbmt": true,
+                            "svinval": true
+                        }
                     }
-                },
-                "virtmem": {
-                    "svnapot": true,
-                    "svpbmt": true,
-                    "svinval": true
-                }
+                ]
             },
             {
                 "hartid": {
@@ -157,21 +173,25 @@
                 "isa": {
                     "riscv64": true
                 },
-                "privileged": {
-                    "modes": {
-                        "u": false,
-                        "m": true,
-                        "s": false
-                    },
-                    "epmp": true,
-                    "satps": {
-                        "sv32": false,
-                        "sv39": false,
-                        "sv48": false,
-                        "sv57": false,
-                        "sv64": false
+                "extensions": [
+                    {
+                        "privileged": {
+                            "modes": {
+                                "u": false,
+                                "m": true,
+                                "s": false
+                            },
+                            "epmp": true,
+                            "satps": {
+                                "sv32": false,
+                                "sv39": false,
+                                "sv48": false,
+                                "sv57": false,
+                                "sv64": false
+                            }
+                        }
                     }
-                }
+                ]
             },
             {
                 "hartid": {
@@ -184,18 +204,24 @@
                         ]
                     }
                 },
-                "fastInt": {
-                    "mModeTimeRegAddr": 4660,
-                    "mModeTimeCompRegAddr": 4660
-                },
-                "zk" : {
-                    "zbkbSupported": true,
-                    "zbkxSupported": true,
-                    "zkndSupported": true,
-                    "zkneSupported": true,
-                    "zknhSupported": true,
-                    "zkrSupported": true
-                }
+                "extensions": [
+                    {
+                        "fastInt": {
+                            "mModeTimeRegAddr": 4660,
+                            "mModeTimeCompRegAddr": 4660
+                        }
+                    },
+                    {
+                        "zk": {
+                            "zbkbSupported": true,
+                            "zbkxSupported": true,
+                            "zkndSupported": true,
+                            "zkneSupported": true,
+                            "zknhSupported": true,
+                            "zkrSupported": true
+                        }
+                    }
+                ]
             }
         ],
         "debugModule": [
@@ -206,7 +232,7 @@
                         "aarsize128Supported": true,
                         "postexecSupported": true,
                         "regno": {
-                            "range" : [
+                            "range": [
                                 {
                                     "start": 4096,
                                     "length": 31
@@ -217,10 +243,10 @@
                 ],
                 "secondary": {
                     "connectedHarts": {
-                        "range" : [
+                        "range": [
                             {
-                                    "start": 0,
-                                    "length": 4
+                                "start": 0,
+                                "length": 4
                             }
                         ]
                     }

--- a/schema/configuration-structure.asn
+++ b/schema/configuration-structure.asn
@@ -43,15 +43,25 @@ BEGIN
         hartId16 FlexibleRange4, /* For hart number [1..16] */
         hartId   FlexibleRange   /* For hart number > 16 */
       },
-      debug Debug OPTIONAL,
+
+      -- Extensions that will not be common on small platforms should go here.
+      -- When these extensions are not used they take no space at all.
+      extensions SEQUENCE OF CHOICE {
+         debug Debug,
+         privileged Privileged,
+         clic Clic,
+         fastInt FastInt,
+         custom SEQUENCE OF Custom,
+         virtmem VirtMem,
+         zjpm Zjpm,
+         zk Zk,
+         ...
+      } OPTIONAL,
+
+      -- Extensions that will be common on small platforms should go here. When
+      -- extensions are actually in use, they take less space in the encoding
+      -- this way.
       isa Isa OPTIONAL,
-      privileged Privileged OPTIONAL,
-      clic Clic OPTIONAL,
-      fastInt FastInt OPTIONAL,
-      custom SEQUENCE OF Custom OPTIONAL,
-      virtmem VirtMem OPTIONAL,
-      zjpm Zjpm OPTIONAL,
-      zk    Zk  OPTIONAL,
       ...
    }
 


### PR DESCRIPTION
This reduces the size of small descriptions (of presumably small
systems), but increases the size of larger descriptions.

Assuming we're going to end up with 53 or so extensions, descriptions
that use 8 or fewer of them will benefit up to 6 bytes from this change.
Descriptions that use 26 extensions in this example would pay 19 bytes.
(If all extensions are used, the cost of this change is 45 bytes.)

Is that a worthwhile trade-off?

In our specific examples, the numbers change:
examples/debug_module.jer stays the same at 18B
examples/example.jer grows from 93B to 97B