### PR TITLE
Limit physical address size to 128 bits.

### DIFF
--- a/schema/helper-types.asn
+++ b/schema/helper-types.asn
@@ -86,5 +86,5 @@ BEGIN
 
    -- A physical address, stored with the least-significant byte first.
    -- Any bytes that are not stored are assumed to be 0.
-   PhysicalAddress ::= OCTET STRING
+   PhysicalAddress ::= OCTET STRING (SIZE(1..16))
 END


### PR DESCRIPTION
Saves space in the structure, and surely 128 bits is enough for any
address.