### PR TITLE
Remove placeholder types.

### DIFF
--- a/examples/example.jer
+++ b/examples/example.jer
@@ -136,23 +136,6 @@
                 },
                 "extensions": [
                     {
-                        "privileged": {
-                            "modes": {
-                                "m": true,
-                                "s": true,
-                                "u": true
-                            },
-                            "epmp": true,
-                            "satps": {
-                                "sv32": false,
-                                "sv39": true,
-                                "sv48": true,
-                                "sv57": true,
-                                "sv64": true
-                            }
-                        }
-                    },
-                    {
                         "virtmem": {
                             "svnapot": true,
                             "svpbmt": true,
@@ -172,26 +155,7 @@
                 },
                 "isa": {
                     "riscv64": true
-                },
-                "extensions": [
-                    {
-                        "privileged": {
-                            "modes": {
-                                "u": false,
-                                "m": true,
-                                "s": false
-                            },
-                            "epmp": true,
-                            "satps": {
-                                "sv32": false,
-                                "sv39": false,
-                                "sv48": false,
-                                "sv57": false,
-                                "sv64": false
-                            }
-                        }
-                    }
-                ]
+                }
             },
             {
                 "hartid": {
@@ -205,12 +169,6 @@
                     }
                 },
                 "extensions": [
-                    {
-                        "fastInt": {
-                            "mModeTimeRegAddr": 4660,
-                            "mModeTimeCompRegAddr": 4660
-                        }
-                    },
                     {
                         "zk": {
                             "zbkbSupported": true,
@@ -252,11 +210,6 @@
                     }
                 }
             }
-        ],
-        "traceModule": {
-            "branchPredictorEntries": 0,
-            "jumpTargetCacheEntries": 0,
-            "contextBusWidth": 32
-        }
+        ]
     }
 }

--- a/schema/configuration-structure.asn
+++ b/schema/configuration-structure.asn
@@ -3,9 +3,9 @@ DEFINITIONS
    AUTOMATIC TAGS ::=
 BEGIN
    IMPORTS Debug, DebugModule FROM Debug-Extension
-      Range, FlexibleRange, FlexibleRange2, FlexibleRange3, FlexibleRange4 FROM Helper-Types
-      Tuple, Triple, PossibleValue, PhysicalAddress FROM Helper-Types
-      Isa, PrivModes, PrivSatps, Privileged FROM Hart-Extension
+      Range, FlexibleRange, FlexibleRange2, FlexibleRange3, FlexibleRange4, PhysicalAddress
+            FROM Helper-Types
+      Isa, PrivModes, PrivSatps FROM Hart-Extension
       VirtMem FROM Virtual-Memory-Extension
       Zjpm FROM Zjpm-Extension
       Zk   FROM Zk-Extensions
@@ -48,9 +48,6 @@ BEGIN
       -- When these extensions are not used they take no space at all.
       extensions SEQUENCE OF CHOICE {
          debug Debug,
-         privileged Privileged,
-         clic Clic,
-         fastInt FastInt,
          custom SEQUENCE OF Custom,
          virtmem VirtMem,
          zjpm Zjpm,
@@ -89,8 +86,6 @@ BEGIN
    Configuration ::= SEQUENCE {
       harts SEQUENCE OF Hart OPTIONAL,
       debugModule SEQUENCE OF DebugModule OPTIONAL,
-      traceModule TraceModule OPTIONAL,
-      physicalMemory SEQUENCE OF PhysicalMemory OPTIONAL,
 
       -- Pointers to additional configuration structures that may be present in
       -- this system. This could be used in multi-socket systems where each chip
@@ -98,38 +93,6 @@ BEGIN
       structurePointers SEQUENCE OF PhysicalAddress OPTIONAL,
 
       custom SEQUENCE OF Custom OPTIONAL,
-      ...
-   }
-
-   Clic ::= SEQUENCE {
-      -- This is a placeholder, which should be filled out with help from the
-      -- fast interrupts group. It should probably be moved into the FastInt
-      -- section.
-      mTimeRegisterAddress INTEGER OPTIONAL,
-      mTimeCompareRegisterAddress INTEGER OPTIONAL,
-      ...
-   }
-   TraceModule ::= SEQUENCE {
-      -- This is a placeholder, which should be filled out with help from the
-      -- trace group.
-      branchPredictorEntries INTEGER OPTIONAL,
-      jumpTargetCacheEntries INTEGER OPTIONAL,
-      contextBusWidth INTEGER OPTIONAL,
-      ...
-   }
-   PhysicalMemory ::= SEQUENCE {
-      -- This is a placeholder that might be useful, but there's no obvious task
-      -- group who would fill it out.
-      address SEQUENCE OF Range,
-      cacheable BOOLEAN OPTIONAL,
-      lrScSupported BOOLEAN OPTIONAL,
-      ...
-   }
-   FastInt ::= SEQUENCE {
-      -- This is a placeholder, which should be filled out with help from the
-      -- fast interrupts group.
-      mModeTimeRegAddr INTEGER OPTIONAL,
-      mModeTimeCompRegAddr INTEGER OPTIONAL,
       ...
    }
 END

--- a/schema/hart-extension.asn
+++ b/schema/hart-extension.asn
@@ -2,11 +2,9 @@ Hart-Extension
 DEFINITIONS
    AUTOMATIC TAGS ::=
 BEGIN
-   EXPORTS Isa, PrivModes, PrivSatps, Privileged;
+   EXPORTS Isa, PrivModes, PrivSatps;
    
    Isa ::= SEQUENCE {
-      -- This is a placeholder, which should be filled out with help from the
-      -- ISA group.
       riscv32 BOOLEAN OPTIONAL,
       riscv64 BOOLEAN OPTIONAL,
       riscv128 BOOLEAN OPTIONAL,
@@ -23,13 +21,5 @@ BEGIN
       sv48 BOOLEAN,
       sv57 BOOLEAN,
       sv64 BOOLEAN
-   }
-   Privileged ::= SEQUENCE {
-      -- This is a placeholder, which should be filled out with help from the
-      -- Privileged group.
-      modes PrivModes OPTIONAL,
-      satps PrivSatps OPTIONAL,
-      epmp BOOLEAN OPTIONAL,
-      ...
    }
 END

--- a/schema/helper-types.asn
+++ b/schema/helper-types.asn
@@ -3,7 +3,7 @@ DEFINITIONS
    AUTOMATIC TAGS ::=
 BEGIN
    EXPORTS FlexibleRange, FlexibleRange2, FlexibleRange3, FlexibleRange4,
-           Range, Tuple, Triple, PossibleValues;
+           Range, Tuple, Triple, PossibleValues, PhysicalAddress;
 
    -- 2-bit integer
    Integer2 ::= INTEGER (0..3)


### PR DESCRIPTION
We have enough real types now that we don't need them as example, and
they definitely should not end up in a frozen schema without input from
the relevant task groups.

I did leave Isa to encode RV32/64/128.