### PR TITLE
Move rvcs to top-level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ release:	$(RELEASE).pdf
 	-o $@ $<
 
 test:
-	./asn1tools/rvcs.py test examples/*.jer
+	./rvcs.py test examples/*.jer
 
 pylint:
-	pylint asn1tools/*.py
+	pylint *.py
 
 clean:
 	rm -f $(DRAFT).pdf $(RELEASE).pdf

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # RISC-V Configuration structure
 
 ## Layout of files here
-- asn1tools/ contains files related to the python asn1tools library. This is
-  where you want to start if you want to encode/decode examples on your PC.
 - examples/ contains human-readable examples.
 - schema/ contains the ASN.1 schema used that describes the configuration structure
   format.
+- rvcs.py is a tool to convert between various human-readable formats and ASN.1
+  formats.
 
 ## Build PDF
 

--- a/rvcs.py
+++ b/rvcs.py
@@ -192,10 +192,10 @@ def schema_path_dict(schema_list):
     return schema_dict
 
 def default_schema_dict():
-    # Walk through ../schema for all standard ASN.1 schema files.
+    # Walk through schema for all standard ASN.1 schema files.
     default_schema_list = []
     for root, _, schemafiles in os.walk(os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "..", "schema")):
+            os.path.dirname(os.path.realpath(__file__)), "schema")):
         for schemafile in schemafiles:
             default_schema_list.append(root + os.path.sep + schemafile)
     return schema_path_dict(default_schema_list)


### PR DESCRIPTION
It's unnecessary to have it in its own subdirectory, which also has a
confusing name.