### PR TITLE
Some minor changes (typos, stylistic, etc)

### DIFF
--- a/src/charter.adoc
+++ b/src/charter.adoc
@@ -3,25 +3,25 @@
 The Unified Discovery Task Group will define a configuration
 structure schema for low-level discovery. A structure using the schema provides the
 information about the existence of RISC-V platform extensions, as well as the parameters
-of such extensions and architectural options. A typical use case of this low-level
-structure is that it is parsed by bootloaders to generate the common structure, e.g. a
-device-tree, that the operating systems expect.
+of such extensions and architectural options. A typical use case for this low-level
+structure is further processing by firmware and/or bootloaders, as part of creating
+platform description structures (e.g. Device Tree, ACPI, SMBIOS) expected by operating
+systems.
 
-The structure does not require a central registry to allow diversified RISC-V
-implementation to communicate any implementation-specific parameters to software. The
-low-level discovery mechanism, e.g. that in a bootloader, should be capable of supporting
-varied use cases from rich operation systems to deeply embedded applications. The
+The structure does not require a central registry, allowing diversified RISC-V
+implementations to communicate any implementation-specific parameters to software. The
+low-level discovery mechanism, e.g. that in a bootloader or firmware, should be capable
+of supporting varying use cases from rich operating systems to deeply embedded applications. The
 configuration structure should also support discovery by external debug tools.
 
-The Task Group will define the specification of the schema of the static data structure
+The Task Group will define the specification of the schema of the static data structure,
 that can accommodate all implementation parameters of RISC-V architecture. The syntax will
-utilize existing established industrial standards ASN.1. A set of rules to utilise X.691
+utilize existing established industrial standards, such as ASN.1. A set of rules to utilise X.691
 to represent the schema will be provided. The specification will eventually be ratified as
 a RISC-V standard.
 
 The Task Group will also provide a proof of concept of the low-level discovery mechanism,
-possibly in an open source boot loader such as uboot. The proof of concept will
+possibly in an open source bootloader or firmware such as uboot. The proof of concept will
 demonstrate how to generate the binary representation from the ASN.1 structure and how to
 parse the binary representation to generate a device-tree. The proof of concept may use
-close-sourced or commercial tools to
-process the ASN.1.
+close-sourced or commercial tools to process the ASN.1.

--- a/src/introduction.adoc
+++ b/src/introduction.adoc
@@ -10,8 +10,8 @@ Unified Discovery, unlocking RISC-V's core."
 
 Unified Discovery is the low-level discovery mechanism for RISC-V, allowing discovery of implemented ISA extensions, configuration options and vendor-specific information through a single, extensible mechanism.
 It exposes the discoverable information both for in-band (hosted) and out-of-band (external debug) use-cases.
-The mechanism and the discoverable information are operating-system agnostic: the Unified Discovery message will typically be used to prepare and produce necessary data that is consumed by operating-system specific, higher-level discovery mechanisms.
-Applications will typicall access a variety of high-level mechanisms (e.g., in Linux use the information from `/proc/cpuinfo` or from the ELF auxiliary vector); a low-level mechanism, such as Unified Discovery, provides the foundation and acts as a source of information.
+The mechanism and the discoverable information are operating system agnostic: the Unified Discovery message will typically be used to prepare and produce necessary data that is consumed by operating system specific, higher-level discovery mechanisms.
+Applications will typically access a variety of high-level mechanisms (e.g., in Linux use the information from `/proc/cpuinfo` or from the ELF auxiliary vector); a low-level mechanism, such as Unified Discovery, provides the foundation and acts as a source of information.
 
 [NOTE]
 ====
@@ -24,7 +24,7 @@ This specification describes Unified Discovery, the RISC-V low-level discovery m
 .. Rich operating systems
 .. Simple software applications
 . Discovery of features by external debug tools
-. Out-of-band discovery of features to allow development tools to specialise firmware (e.g. choose the appropriate target flags for compilation and link in the required libraries) for deeply embedded applications
+. Out-of-band discovery of features to allow development tools to specialise firmware for deeply embedded applications (e.g. choose the appropriate target flags for compilation and linking) 
 
 As an example, consider a typical Linux stack:
 
@@ -48,7 +48,7 @@ Unified Discovery is extensible without the need for a central registry of vendo
 RISC-V allows the vendor-defined extensibility of the ISA, through vendor-defined extensions that reside in the `custom`-opcode space` without any coordination with RISC-V International (as long as no required features are removed and no incompatible features are introduced).
 This flexible and decentralized evolution of the RISC-V ISA is reflected in the architecture of Unified Discovery, as it requires minimum coordination between implementators and RISC-V International:
 
-. Based on the published modelling language, encoding rules and the top-level message schema), implementers (both for soft- and hardware) are able to:
+. Based on the published modeling language, encoding rules and the top-level message schema), implementers (both for soft- and hardware) are able to:
 .. add proprietary entries in the configuration message, that can safely be identified, read-over (i.e., skipped) or referenced back to the vendor (without a global vendor registry being operated by RISC-V) that specified the proprietary entry format
 .. parse any configuration message, including the ability:
 ... to parse a newer-version message, identifying the new “extensions” and being able to safely skip over them


### PR DESCRIPTION
Reword some of the text.

One thing of note is that the charter referred to a "bootloader" generating DT based on UD data, whereas in a normal non-embedded environment it would be firmware (eg  coreboot, UEFI, w/e), not the OS loader (and uboot is really more firmware than a pure loader, esp. when it is used to modern OSes)