### PR TITLE
introduction: remove cryptographic message syntax wrapping

### DIFF
--- a/src/introduction.adoc
+++ b/src/introduction.adoc
@@ -69,18 +69,3 @@ in the message. This is termed the *Complete Consumption Requirement*.
 =====
 The complete consumption requirement is one of the unresolvable issues for CPUID-style instructions that query for values using keys.
 =====
-
-=== Integrating message authenticity
-
-While the basic Unified Discovery specification does not mandate message security, the discovery information is wrapped in a Cryptographic Message Syntax (RFC5652) envelope to allow for future extensability encompassing message authentication and protection against replay attacks.
-Signing the configuration message is supported as an integral (albeit optional) part of the message format.
-
-We expect future extensions to Unified Discovery to make use of this mechanism to enhance security:
-
-. static signing (establishes the integrity and originator of a message)
-.. does not protect against replay attacks
-.. is supported out-of-the-box and without the need for an additional active component by populating the signerInfos field of the CMS envelope
-. dynamic signing (protects against replay-attacks)
-.. will require an additional mechanism, in addition to the read-only `mconfigptr` CSR, to issue a challenge to an active component that manages the Unified Discovery message
-.. can utilize the CMS envelope to provide a signature of the Unified Discovery data _and_ of a signed-attribute that contains a response derived from the challenge
-

--- a/src/referenced-standards.adoc
+++ b/src/referenced-standards.adoc
@@ -10,8 +10,3 @@ RISC-V Unified Discovery builds on the X.680-X.693 ("Information Technology - Ab
 . X.691: Information technology - ASN.1 encoding rules: Specification of Packed Encoding Rules (PER) https://www.itu.int/rec/T-REC-X.691/en[Link]
 
 The X.680-X.693 standards are well established, openly available standards that are proven building blocks for a wide variety of information technology applications, including X.509 digital certificates, SNMP, LDAP, ISO 7816-4 smartcards, 4G/LTE, and 5G.
-
-RISC-V Unified Discovery message security builds on:
-. IETF https://datatracker.ietf.org/doc/html/rfc5652[RFC 5652]: Cryptographic Message Syntax (CMS)
-. IETF https://datatracker.ietf.org/doc/html/rfc6268[RFC 6268]: Additional New ASN.1 Modules for the Cryptographic Message Syntax (CMS) and the Public Key Infrastructure Using X.509 (PKIX)
-. IETF https://datatracker.ietf.org/doc/html/rfc8933[RFC 8933]: Update to the Cryptographic Message Syntax (CMS) for Algorithm Identifier Protection

--- a/src/schema.adoc
+++ b/src/schema.adoc
@@ -12,31 +12,6 @@ RISCV-Unified-Discovery DEFINITIONS AUTOMATIC TAGS ::=
 BEGIN
 ....
 
-The header is followed by the import segment for the `SignedData` type from Cryptographic 
-Message Syntax. This is used to provide the envelope for message authentication.
-....
-IMPORTS
-  SignedData
-  FROM CryptographicMessageSyntax-2010
-    { iso(1) member-body(2) us(840) rsadsi(113549)
-          pkcs(1) pkcs-9(9) smime(16) modules(0) id-mod-cms-2009(58) };
-....
-
-The envelope type follows the import segment. Signing of the message is optional.
-
-....
-  UnifiedDiscoveryEnvelop ::= SignedData
-....
-
-The content type in the `SignedData` is encoded as an object identifier. Two such 
-identifiers are specified. Each corresponds to an encoding scheme.
-
-....
-  id-UnifiedDiscovery-UPERencoded OBJECT IDENTIFIER ::= {
-  ...
-  id-UnifiedDiscovery-DERencoded OBJECT IDENTIFIER ::= {
-....
-
 In the value notations, vendors can specify the JEDEC manufacturers identifier to identify 
 themselves.  The `JEDEC-ID` type provides the short-hand type.
 

--- a/src/solution-outline.adoc
+++ b/src/solution-outline.adoc
@@ -58,8 +58,7 @@ additional CSR are required.
 
 The discovery data encoded uses standardized encoding rules (see ITU-T X.690 and ISO 
 8825).  For in-memory representations, the unaligned packed encoding rules (unaligned PER, 
-see ITU-T X.691) are used. The configuration data can (optionally) be cryptographically 
-signed.
+see ITU-T X.691) are used.
 
 Target software (usually firmware) that performs discovery will read the uPER-encoded 
 message to retrieve the relevant configuration elements. The message can be decoded either 
@@ -83,10 +82,6 @@ The unified discovery mechanism for RISC-V builds on the following technology st
 
 . RISC-V International specific guidelines to allow the efficient aggregation of RISC-V 
 global and vendor-specific data elements without a central registration authority
-
-. RISC-V International specific guidelines for the encoding of detached signatures 
-(PKCS#7/CMS) using Packed Encoding Rules
-
 
 NOTE: The benefits of using X.680 and X.693 over vendor-specific (e.g. Google Protobuf, 
 Apache Avro etc.) marshalling frameworks are the fact that these are international 

--- a/unified_discovery_schema.asn1
+++ b/unified_discovery_schema.asn1
@@ -5,31 +5,6 @@
 
 RISCV-Unified-Discovery DEFINITIONS AUTOMATIC TAGS ::=
 BEGIN
-IMPORTS
-  SignedData
-  FROM CryptographicMessageSyntax-2010
-    { iso(1) member-body(2) us(840) rsadsi(113549)
-          pkcs(1) pkcs-9(9) smime(16) modules(0) id-mod-cms-2009(58) };
-
-  -- Each Unified Discovery message is wrapped in CMS (Cryptographic
-  -- Message Syntax) SignedData envelope to provide support for
-  -- message authentication.  Signing of the message is optional.
-  -- Cf. Unified Discovery specification, section [TODO: 1.x].
-  UnifiedDiscoveryEnvelope ::= SignedData
-
-  -- The content type in CMS is encoded as an object identifier.
-  -- Unified Discovery specifies two such content types:
-  --  1. UPER-encoded U/D  (cf. section [TODO])
-  --  2. DER-encoded U/D   (cf. section [TODO])
-  id-UnifiedDiscovery-UPERencoded OBJECT IDENTIFIER ::= {
-         iso(1) identified-organization(3) dod(6) internet(1)
-	 private(4) enterprise(1) 57194
-	 unified-discovery(1) uper-encoded-content(2) }
-  id-UnifiedDiscovery-DERencoded OBJECT IDENTIFIER ::= {
-         iso(1) identified-organization(3) dod(6) internet(1)
-	 private(4) enterprise(1) 57194
-	 unified-discovery(1) uper-encoded-content(1) }
-
   -- RISC-V sometimes uses JEDEC manufacturers identification code to
   -- identify implementers.  Each JEDEC manufacturers identification
   -- code (see JEDEC JEP106) is made up of one or more 8 bit fields


### PR DESCRIPTION
The reader of UD must unconditionally trust the platform and all M-mode code that executed before it.

Remove the CMS wrapping as it doesn't improve security and only complicates decoding.